### PR TITLE
Add utilities and handling for exceeding GitHub request limits

### DIFF
--- a/calamari-core/.gitignore
+++ b/calamari-core/.gitignore
@@ -3,3 +3,4 @@
 /.settings/
 /bin/
 /build/
+/test-output/

--- a/calamari-core/src/main/java/org/starchartlabs/calamari/core/ResponseConditions.java
+++ b/calamari-core/src/main/java/org/starchartlabs/calamari/core/ResponseConditions.java
@@ -44,7 +44,7 @@ public class ResponseConditions {
      *            OkHttp3 representation of a web response
      * @since 0.1.0
      */
-    public static <T> void checkRateLimit(Response response) throws RequestLimitExceededException {
+    public static void checkRateLimit(Response response) throws RequestLimitExceededException {
         Objects.requireNonNull(response);
 
         checkRateLimit(response, Response::code, (res, header) -> res.headers().values(header));
@@ -63,6 +63,8 @@ public class ResponseConditions {
      * @param headerLookup
      *            Function which takes a response and header value as input, and produces all instances of that header
      *            from the response
+     * @param <T>
+     *            Java type representing a web response
      * @throws RequestLimitExceededException
      *             If the provided response represents exceeding GitHub's rate limiting
      * @since 0.1.0

--- a/calamari-core/src/main/java/org/starchartlabs/calamari/core/ResponseConditions.java
+++ b/calamari-core/src/main/java/org/starchartlabs/calamari/core/ResponseConditions.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2018 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.calamari.core;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.starchartlabs.calamari.core.exception.RequestLimitExceededException;
+
+import okhttp3.Response;
+
+/**
+ * Provides streamlined checking for common responses from GitHub
+ *
+ * @author romeara
+ * @since 0.1.0
+ */
+public class ResponseConditions {
+
+    private static final String RATE_LIMIT_MAXIMUM_HEADER = "X-RateLimit-Limit";
+
+    private static final String RATE_LIMIT_RESET_HEADER = "X-RateLimit-Reset";
+
+    private static final String RATE_LIMIT_REMAINING_HEADER = "X-RateLimit-Remaining";
+
+    /**
+     * Analyzes a web response to determine if it represents exceeding GitHub's rate limits
+     *
+     * <p>
+     * If the response does represent exceeded rate limiting, throws a {@link RequestLimitExceededException}
+     *
+     * <p>
+     * To use this check with other web libraries, see {@link #checkRateLimit(Object, Function, BiFunction)}
+     *
+     * @param response
+     *            OkHttp3 representation of a web response
+     * @since 0.1.0
+     */
+    public static <T> void checkRateLimit(Response response) throws RequestLimitExceededException {
+        Objects.requireNonNull(response);
+
+        checkRateLimit(response, Response::code, (res, header) -> res.headers().values(header));
+    }
+
+    /**
+     * Analyzes a web response to determine if it represents exceeding GitHub's rate limits
+     *
+     * <p>
+     * If the response does represent exceeded rate limiting, throws a {@link RequestLimitExceededException}
+     *
+     * @param response
+     *            Representation of a web response
+     * @param codeLookup
+     *            Function which reads the HTTP status code from the provided response
+     * @param headerLookup
+     *            Function which takes a response and header value as input, and produces all instances of that header
+     *            from the response
+     * @throws RequestLimitExceededException
+     *             If the provided response represents exceeding GitHub's rate limiting
+     * @since 0.1.0
+     */
+    public static <T> void checkRateLimit(T response, Function<T, Integer> codeLookup,
+            BiFunction<T, String, Collection<String>> headerLookup) throws RequestLimitExceededException {
+        Objects.requireNonNull(response);
+        Objects.requireNonNull(headerLookup);
+
+        String limit = Optional.ofNullable(headerLookup.apply(response, RATE_LIMIT_MAXIMUM_HEADER))
+                .orElse(Collections.emptyList())
+                .stream()
+                .findFirst()
+                .orElse("(unknown)");
+
+        String reset = Optional.ofNullable(headerLookup.apply(response, RATE_LIMIT_RESET_HEADER))
+                .orElse(Collections.emptyList())
+                .stream()
+                .findFirst()
+                .orElse("(unknown)");
+
+        Collection<String> remaining = Optional.ofNullable(headerLookup.apply(response, RATE_LIMIT_REMAINING_HEADER))
+                .orElse(Collections.emptyList());
+
+        boolean rateLimitExceeded = Objects.equals(codeLookup.apply(response), 403) && remaining.contains("0");
+
+        if (rateLimitExceeded) {
+            throw new RequestLimitExceededException(limit, reset);
+        }
+    }
+
+}

--- a/calamari-core/src/main/java/org/starchartlabs/calamari/core/exception/RequestLimitExceededException.java
+++ b/calamari-core/src/main/java/org/starchartlabs/calamari/core/exception/RequestLimitExceededException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2018 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.calamari.core.exception;
+
+import org.starchartlabs.alloy.core.Strings;
+
+/**
+ * Represents a request to GitHub which failed due to the calling application exceeding allotted its rate limits
+ *
+ * <p>
+ * See the <a href="https://developer.github.com/v3/#rate-limiting">GitHub API rate limit documentation</a>
+ *
+ * @author romeara
+ * @since 0.1.0
+ */
+public class RequestLimitExceededException extends RuntimeException {
+
+    private static final long serialVersionUID = 3619506905378504972L;
+
+    /**
+     * @param limit
+     *            The number of requests allowed per time period
+     * @param reset
+     *            The amount of time before the number of allowed requests resets
+     * @since 0.1.0
+     */
+    public RequestLimitExceededException(String limit, String reset) {
+        super(Strings.format("Maximum requests to GitHub exceeded. Limit of %s, resets at %s", limit, reset));
+    }
+
+    /**
+     * @param limit
+     *            The number of requests allowed per time period
+     * @param reset
+     *            The amount of time before the number of allowed requests resets
+     * @param cause
+     *            The root cause that indicated an error occurred
+     * @since 0.1.0
+     */
+    public RequestLimitExceededException(String limit, String reset, Throwable cause) {
+        super(Strings.format("Maximum requests to GitHub exceeded. Limit of %s, resets at %s", limit, reset), cause);
+    }
+
+}

--- a/calamari-core/src/test/java/org/starchartlabs/calamari/test/core/ResponseConditionsTest.java
+++ b/calamari-core/src/test/java/org/starchartlabs/calamari/test/core/ResponseConditionsTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2018 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.calamari.test.core;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.starchartlabs.calamari.core.ResponseConditions;
+import org.starchartlabs.calamari.core.exception.RequestLimitExceededException;
+import org.testng.annotations.Test;
+
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class ResponseConditionsTest {
+
+    private static final String RATE_LIMIT_MAXIMUM_HEADER = "X-RateLimit-Limit";
+
+    private static final String RATE_LIMIT_RESET_HEADER = "X-RateLimit-Reset";
+
+    private static final String RATE_LIMIT_REMAINING_HEADER = "X-RateLimit-Remaining";
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void checkRateLimitResponseNullResponse() throws Exception {
+        ResponseConditions.checkRateLimit(null);
+    }
+
+    @Test
+    public void checkRateLimitResponseNotExceeded() throws Exception {
+        Response response = getResponseBuilder()
+                .code(100)
+                .header(RATE_LIMIT_MAXIMUM_HEADER, "1000")
+                .header(RATE_LIMIT_RESET_HEADER, "5")
+                .header(RATE_LIMIT_REMAINING_HEADER, "500")
+                .build();
+
+        ResponseConditions.checkRateLimit(response);
+    }
+
+    @Test
+    public void checkRateLimitResponseNotExceededForbidden() throws Exception {
+        Response response = getResponseBuilder()
+                .code(403)
+                .header(RATE_LIMIT_MAXIMUM_HEADER, "1000")
+                .header(RATE_LIMIT_RESET_HEADER, "5")
+                .header(RATE_LIMIT_REMAINING_HEADER, "500")
+                .build();
+
+        ResponseConditions.checkRateLimit(response);
+    }
+
+    @Test(expectedExceptions = RequestLimitExceededException.class)
+    public void checkRateLimitResponse() throws Exception {
+        Response response = getResponseBuilder()
+                .code(403)
+                .header(RATE_LIMIT_MAXIMUM_HEADER, "1000")
+                .header(RATE_LIMIT_RESET_HEADER, "5")
+                .header(RATE_LIMIT_REMAINING_HEADER, "0")
+                .build();
+
+        ResponseConditions.checkRateLimit(response);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void checkRateLimitNullResponse() throws Exception {
+        ResponseConditions.checkRateLimit((String) null, a -> 100, (a, b) -> Collections.emptyList());
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void checkRateLimitNullCodeLookup() throws Exception {
+        ResponseConditions.checkRateLimit("a", null, (a, b) -> Collections.emptyList());
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void checkRateLimitNullHeaderLookup() throws Exception {
+        ResponseConditions.checkRateLimit("a", a -> 100, null);
+    }
+
+    @Test
+    public void checkRateLimitNotExceeded() throws Exception {
+        Map<String, Collection<String>> headers = new HashMap<>();
+        headers.put(RATE_LIMIT_MAXIMUM_HEADER, Collections.singleton("1000"));
+        headers.put(RATE_LIMIT_RESET_HEADER, Collections.singleton("5"));
+        headers.put(RATE_LIMIT_REMAINING_HEADER, Collections.singleton("500"));
+
+        ResponseConditions.checkRateLimit("a", a -> 100, (a, b) -> headers.get(b));
+    }
+
+    @Test
+    public void checkRateLimitNotExceededForbidden() throws Exception {
+        Map<String, Collection<String>> headers = new HashMap<>();
+        headers.put(RATE_LIMIT_MAXIMUM_HEADER, Collections.singleton("1000"));
+        headers.put(RATE_LIMIT_RESET_HEADER, Collections.singleton("5"));
+        headers.put(RATE_LIMIT_REMAINING_HEADER, Collections.singleton("500"));
+
+        ResponseConditions.checkRateLimit("a", a -> 403, (a, b) -> headers.get(b));
+    }
+
+    @Test(expectedExceptions = RequestLimitExceededException.class)
+    public void checkRateLimit() throws Exception {
+        Map<String, Collection<String>> headers = new HashMap<>();
+        headers.put(RATE_LIMIT_MAXIMUM_HEADER, Collections.singleton("1000"));
+        headers.put(RATE_LIMIT_RESET_HEADER, Collections.singleton("5"));
+        headers.put(RATE_LIMIT_REMAINING_HEADER, Collections.singleton("0"));
+
+        ResponseConditions.checkRateLimit("a", a -> 403, (a, b) -> headers.get(b));
+    }
+
+    private Response.Builder getResponseBuilder() {
+        return new Response.Builder()
+                .request(new Request.Builder().url("http://localhost").build())
+                .protocol(Protocol.HTTP_1_1)
+                .message("message");
+    }
+
+}

--- a/calamari-core/src/test/java/org/starchartlabs/calamari/test/core/exception/RequestLimitExceededExceptionTest.java
+++ b/calamari-core/src/test/java/org/starchartlabs/calamari/test/core/exception/RequestLimitExceededExceptionTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2018 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.calamari.test.core.exception;
+
+import org.starchartlabs.calamari.core.exception.RequestLimitExceededException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class RequestLimitExceededExceptionTest {
+
+    @Test
+    public void constructNoCause() throws Exception {
+        RequestLimitExceededException result = new RequestLimitExceededException("(limit)", "(reset)");
+
+        Assert.assertEquals(result.getMessage(),
+                "Maximum requests to GitHub exceeded. Limit of (limit), resets at (reset)");
+        Assert.assertNull(result.getCause());
+    }
+
+    @Test
+    public void constructWithCause() throws Exception {
+        RuntimeException cause = new RuntimeException();
+        RequestLimitExceededException result = new RequestLimitExceededException("(limit)", "(reset)", cause);
+
+        Assert.assertEquals(result.getMessage(),
+                "Maximum requests to GitHub exceeded. Limit of (limit), resets at (reset)");
+        Assert.assertEquals(result.getCause(), cause);
+    }
+
+}


### PR DESCRIPTION
Part of GitHub's API behavior is the concept of limiting the rate of
requests from a client to a specific value, and responding in a
consistent way when that limit is exceeded.

This change adds utilities to recognize when a response represents a
rate limit exceeded error, and translating that into a Java exception