### PR TITLE
Add calamari-core description

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Add description to deployment of calamari-core project
 
 ## [0.1.0]
 ### Added

--- a/calamari-core/build.gradle
+++ b/calamari-core/build.gradle
@@ -1,3 +1,5 @@
+description = 'Utilities for interacting with GitHub as a GitHub App'
+
 dependencies {
     compile 'com.google.code.findbugs:jsr305'
     compile 'com.google.code.gson:gson'


### PR DESCRIPTION
Maven insists on a project description for deployment