### PR TITLE
GH-5 Expose installation URL lookup as reusable function

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Add InstallationAccessToken.getInstallationUrl to allow more complex client caching behavior
 
 ## [0.1.1]
 - Add description to deployment of calamari-core project

--- a/calamari-core/src/main/java/org/starchartlabs/calamari/core/auth/InstallationAccessToken.java
+++ b/calamari-core/src/main/java/org/starchartlabs/calamari/core/auth/InstallationAccessToken.java
@@ -161,7 +161,6 @@ public class InstallationAccessToken implements Supplier<String> {
         return new InstallationAccessToken(installationAccessTokenUrl, applicationKey, userAgent);
     }
 
-    // TODO romeara
     /**
      * Looks up the location of the resource describing the installation for a given repository
      *


### PR DESCRIPTION
Allow clients to lookup the installation URL, which in turn allows
clients to be more sophisticated in caching tokens and reducing calls to
GitHub