### PR TITLE
GH-7 Update InstallationAccessToken to properly close ResponseBody

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,11 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Updated InstallationAccessToken.generateNewToken to close OkHttp response body
 
 ## [0.2.0]
+### Added
 - Add InstallationAccessToken.getInstallationUrl to allow more complex client caching behavior
 
 ## [0.1.1]
+### Added
 - Add description to deployment of calamari-core project
 
 ## [0.1.0]

--- a/calamari-core/src/main/java/org/starchartlabs/calamari/core/auth/InstallationAccessToken.java
+++ b/calamari-core/src/main/java/org/starchartlabs/calamari/core/auth/InstallationAccessToken.java
@@ -27,6 +27,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 
 /**
  * Represents an access token used to validate web requests to GitHub as a
@@ -106,9 +107,9 @@ public class InstallationAccessToken implements Supplier<String> {
     private String generateNewToken() {
         HttpUrl url = HttpUrl.parse(installationAccessTokenUrl);
 
-        RequestBody body = RequestBody.create(null, new byte[] {});
+        RequestBody requestBody = RequestBody.create(null, new byte[] {});
         Request request = new Request.Builder()
-                .post(body)
+                .post(requestBody)
                 .header("Authorization", applicationKey.get())
                 .header("Accept", MediaTypes.APP_PREVIEW)
                 .header("User-Agent", userAgent)
@@ -117,7 +118,9 @@ public class InstallationAccessToken implements Supplier<String> {
 
         try (Response response = httpClient.newCall(request).execute()) {
             if (response.isSuccessful()) {
-                return AccessTokenResponse.fromJson(response.body().string()).getToken();
+                try (ResponseBody body = response.body()) {
+                    return AccessTokenResponse.fromJson(body.string()).getToken();
+                }
             } else {
                 ResponseConditions.checkRateLimit(response);
 


### PR DESCRIPTION
OkHttp's response API contains a ResponseBody object, which is a
closeable resource. Previously, this was being accessed in-line without
being closed

This change extracts it and uses it within a try-with-resources,
ensuring it closes once access is no longer needed