### PR TITLE
Add utility for reading text-based file content from GitHub

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added org.starchartlabs.calamari.core.content.ConfigurationFileLoader for reading configuration file contents from GitHub
 
 ## [0.2.1]
 ### Fixed

--- a/calamari-core/build.gradle
+++ b/calamari-core/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     compile 'org.starchartlabs.alloy:alloy-core'
     
     testCompile 'com.squareup.okhttp3:mockwebserver'
+    testCompile 'org.mockito:mockito-core'
     testCompile 'org.testng:testng'
     
     testRuntime 'org.slf4j:slf4j-simple'

--- a/calamari-core/src/main/java/org/starchartlabs/calamari/core/content/FileContentLoader.java
+++ b/calamari-core/src/main/java/org/starchartlabs/calamari/core/content/FileContentLoader.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) Jan 16, 2019 StarChart Labs Authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ */
+package org.starchartlabs.calamari.core.content;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.starchartlabs.alloy.core.Preconditions;
+import org.starchartlabs.alloy.core.Strings;
+import org.starchartlabs.calamari.core.MediaTypes;
+import org.starchartlabs.calamari.core.ResponseConditions;
+import org.starchartlabs.calamari.core.auth.InstallationAccessToken;
+import org.starchartlabs.calamari.core.exception.FileContentException;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.annotations.SerializedName;
+
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+/**
+ * Represents handling for reading the contents of a configuration file from a GitHub repository
+ *
+ * <p>
+ * It is intended for an application to create a single loader instance for a configuration file, and utilize
+ * {@link #loadContents(InstallationAccessToken, String, String, String)} for each individual repository lookup desired
+ *
+ * @author romeara
+ * @since 0.3.0
+ */
+public class FileContentLoader {
+
+    /** Logger reference to output information to the application log files */
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final OkHttpClient httpClient;
+
+    private final String userAgent;
+
+    /**
+     * @param userAgent
+     *            The user agent to make web requests as, as
+     *            <a href="https://developer.github.com/v3/#user-agent-required">required by GitHub</a>
+     * @since 0.3.0
+     */
+    public FileContentLoader(String userAgent) {
+        this.userAgent = Objects.requireNonNull(userAgent);
+
+        httpClient = new OkHttpClient();
+    }
+
+    /**
+     * Reads contents of the configuration file specified at construction as per the
+     * <a href="https://developer.github.com/v3/repos/contents/">GitHub file content API specification</a>
+     *
+     * @param installationToken
+     *            Token specific to an application/repository authorizing a GitHub App to take actions on GitHub
+     * @param repositoryUrl
+     *            The URL of the repository to read configuration file contents from
+     * @param ref
+     *            The branch/tag to read contents from
+     * @param path
+     *            The repository-root relative path to the configuration file to read when loading contents
+     * @return Plain-text file contents, if the file existed in the repository on the given branch/tag
+     * @since 0.3.0
+     */
+    public Optional<String> loadContents(InstallationAccessToken installationToken, String repositoryUrl, String ref,
+            String path) {
+        Objects.requireNonNull(installationToken);
+        Objects.requireNonNull(repositoryUrl);
+        Objects.requireNonNull(ref);
+        Objects.requireNonNull(path);
+
+        String result = null;
+        String responseBody = null;
+        Request request = createRequest(installationToken, repositoryUrl, ref, path);
+
+        try (Response response = httpClient.newCall(request).execute()) {
+            if (response.isSuccessful()) {
+                try (ResponseBody body = response.body()) {
+                    responseBody = body.string();
+                    result = deserializeResponse(responseBody);
+                }
+            } else if (response.code() != 404) {
+                ResponseConditions.checkRateLimit(response);
+
+                throw new FileContentException(
+                        "Request unsuccessful (" + response.code() + " - " + response.message() + ")");
+            }
+
+            return Optional.ofNullable(result);
+        } catch (IOException | JsonSyntaxException e) {
+            logger.error("Error reading contents: {}", responseBody);
+
+            throw new FileContentException(
+                    "Error requesting or deserializing GitHub file content response.", e);
+        }
+    }
+
+    /**
+     * Generates an HTTP request representation for the given repository
+     *
+     * @param installationToken
+     *            Token specific to an application/repository authorizing a GitHub App to take actions on GitHub
+     * @param repositoryUrl
+     *            The URL of the repository to read configuration file contents from
+     * @param ref
+     *            The branch/tag to read contents from
+     * @param path
+     *            The repository-root relative path to the configuration file to read when loading contents
+     * @return HTTP request for the repository, including authorization headers
+     */
+    private Request createRequest(InstallationAccessToken installationToken, String repositoryUrl, String ref,
+            String path) {
+        HttpUrl url = HttpUrl.parse(repositoryUrl).newBuilder()
+                .addEncodedPathSegment("contents")
+                .addPathSegments(path)
+                .addQueryParameter("ref", ref)
+                .build();
+
+        return new Request.Builder()
+                .get()
+                .header("Authorization", installationToken.get())
+                .header("Accept", MediaTypes.APP_PREVIEW)
+                .header("User-Agent", userAgent)
+                .url(url)
+                .build();
+    }
+
+    /**
+     * Takes a raw JSON response body from GitHub and deserializes it into plain text
+     *
+     * @param responseBody
+     *            JSON-encoded response
+     * @return Plain text file contents
+     */
+    private String deserializeResponse(String responseBody) {
+        Objects.requireNonNull(responseBody);
+
+        String result = null;
+        ContentResponse content = ContentResponse.fromJson(responseBody);
+
+        Preconditions.checkArgument(Objects.equals(content.getEncoding(), "base64"),
+                Strings.format(
+                        "GitHub content responses are expected to be of base64 encoding, got %s - check that requested path is a file",
+                        content.getEncoding()));
+
+        try {
+            // Note: Both UTF-8 and the mime-decoder were determined experimentally
+            // For discussion and write-up, see:
+            // https://stackoverflow.com/questions/40768678/decoding-base64-while-using-github-api-to-download-a-file/54302528#54302528
+            result = new String(
+                    Base64.getMimeDecoder().decode(content.getContent().getBytes(StandardCharsets.UTF_8)));
+        } catch (IllegalArgumentException e) {
+            logger.error("Error deserializing base64 from response: {}", responseBody, e);
+
+            throw new FileContentException("Error deserializing base64 from GitHub response", e);
+        }
+
+        return result;
+    }
+
+    /**
+     * Represents JSON structure provided by GitHub for file contents
+     *
+     * @author romeara
+     */
+    private static final class ContentResponse {
+
+        private static final Gson GSON = new GsonBuilder().create();
+
+        @SerializedName("encoding")
+        private final String encoding;
+
+        @SerializedName("content")
+        private final String content;
+
+        @SuppressWarnings("unused")
+        public ContentResponse(String encoding, String content) {
+            this.encoding = Objects.requireNonNull(encoding);
+            this.content = Objects.requireNonNull(content);
+        }
+
+        public String getEncoding() {
+            return encoding;
+        }
+
+        public String getContent() {
+            return content;
+        }
+
+        public static ContentResponse fromJson(String json) {
+            return GSON.fromJson(json, ContentResponse.class);
+        }
+
+    }
+
+}

--- a/calamari-core/src/main/java/org/starchartlabs/calamari/core/content/package-info.java
+++ b/calamari-core/src/main/java/org/starchartlabs/calamari/core/content/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+/**
+ * Utilities for reading and manipulating file content on GitHub as a GitHub App
+ *
+ * @author romeara
+ */
+@ParametersAreNonnullByDefault
+package org.starchartlabs.calamari.core.content;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/calamari-core/src/main/java/org/starchartlabs/calamari/core/exception/FileContentException.java
+++ b/calamari-core/src/main/java/org/starchartlabs/calamari/core/exception/FileContentException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.calamari.core.exception;
+
+/**
+ * Represents an error during the process of reading/deserializing file content stored on GitHub
+ *
+ * @author romeara
+ * @since 0.3.0
+ */
+public class FileContentException extends RuntimeException {
+
+    private static final long serialVersionUID = 1999424194651574510L;
+
+    /**
+     * @param message
+     *            Description of the exceptional condition which could not be recovered from
+     * @since 0.3.0
+     */
+    public FileContentException(String message) {
+        super(message);
+    }
+
+    /**
+     * @param message
+     *            Description of the exceptional condition which could not be recovered from
+     * @param cause
+     *            The root cause of the error
+     * @since 0.3.0
+     */
+    public FileContentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/calamari-core/src/test/java/org/starchartlabs/calamari/test/core/content/FileContentLoaderTest.java
+++ b/calamari-core/src/test/java/org/starchartlabs/calamari/test/core/content/FileContentLoaderTest.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) Jan 21, 2019 StarChart Labs Authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ */
+package org.starchartlabs.calamari.test.core.content;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.starchartlabs.calamari.core.MediaTypes;
+import org.starchartlabs.calamari.core.auth.InstallationAccessToken;
+import org.starchartlabs.calamari.core.content.FileContentLoader;
+import org.starchartlabs.calamari.core.exception.FileContentException;
+import org.starchartlabs.calamari.core.exception.RequestLimitExceededException;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+public class FileContentLoaderTest {
+
+    private static final String RATE_LIMIT_REMAINING_HEADER = "X-RateLimit-Remaining";
+
+    private static final Path TEST_RESOURCE_FOLDER = Paths.get("org", "starchartlabs", "calamari", "test", "core",
+            "content");
+
+    @Mock
+    private InstallationAccessToken accessToken;
+
+    private FileContentLoader fileContentLoader;
+
+    @BeforeMethod
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        fileContentLoader = new FileContentLoader("userAgent");
+    }
+
+    @AfterMethod
+    public void teardown() {
+        Mockito.verifyNoMoreInteractions(accessToken);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullUserAgent() throws Exception {
+        new FileContentLoader(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void loadContentsNullAccessToken() throws Exception {
+        fileContentLoader.loadContents(null, "repositoryUrl", "ref", "path.json");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void loadContentsNullRepositoryUrl() throws Exception {
+        fileContentLoader.loadContents(accessToken, null, "ref", "path.json");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void loadContentsNullRef() throws Exception {
+        fileContentLoader.loadContents(accessToken, "repositoryUrl", null, "path.json");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void loadContentsNullPath() throws Exception {
+        fileContentLoader.loadContents(accessToken, "repositoryUrl", "ref", null);
+    }
+
+
+    @Test(expectedExceptions = FileContentException.class)
+    public void loadContentsErrorResponse() throws Exception {
+        MockResponse response = new MockResponse()
+                .setResponseCode(412);
+
+        String owner = "owner";
+        String repository = "repository";
+        String ref = "ref";
+        String path = "path.json";
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(response);
+            server.start();
+
+            String repositoryUrl = server.url("/api/repos/" + owner + "/" + repository).toString();
+
+            FileContentLoader contentLoader = new FileContentLoader("userAgent");
+
+            Mockito.when(accessToken.get()).thenReturn("token authToken12345");
+
+            try {
+                contentLoader.loadContents(accessToken, repositoryUrl, ref, path);
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 1);
+                RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request.getHeader("User-Agent"), "userAgent");
+                Assert.assertEquals(request.getHeader("Accept"), MediaTypes.APP_PREVIEW);
+                Assert.assertEquals(request.getHeader("Authorization"), "token authToken12345");
+                Assert.assertEquals(request.getPath(),
+                        "/api/repos/" + owner + "/" + repository + "/contents/" + path + "?ref=" + ref);
+
+                Mockito.verify(accessToken).get();
+            }
+        }
+    }
+
+    @Test(expectedExceptions = RequestLimitExceededException.class)
+    public void loadContentsRateLimitExceeded() throws Exception {
+        MockResponse response = new MockResponse()
+                .setResponseCode(403)
+                .addHeader(RATE_LIMIT_REMAINING_HEADER, "0");
+
+        String owner = "owner";
+        String repository = "repository";
+        String ref = "ref";
+        String path = "path.json";
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(response);
+            server.start();
+
+            String repositoryUrl = server.url("/api/repos/" + owner + "/" + repository).toString();
+
+            FileContentLoader contentLoader = new FileContentLoader("userAgent");
+
+            Mockito.when(accessToken.get()).thenReturn("token authToken12345");
+
+            try {
+                contentLoader.loadContents(accessToken, repositoryUrl, ref, path);
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 1);
+                RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request.getHeader("User-Agent"), "userAgent");
+                Assert.assertEquals(request.getHeader("Accept"), MediaTypes.APP_PREVIEW);
+                Assert.assertEquals(request.getHeader("Authorization"), "token authToken12345");
+                Assert.assertEquals(request.getPath(),
+                        "/api/repos/" + owner + "/" + repository + "/contents/" + path + "?ref=" + ref);
+
+                Mockito.verify(accessToken).get();
+            }
+        }
+    }
+
+    @Test
+    public void loadContentsNotFound() throws Exception {
+        MockResponse response = new MockResponse()
+                .setResponseCode(404);
+
+        String owner = "owner";
+        String repository = "repository";
+        String ref = "ref";
+        String path = "path.json";
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(response);
+            server.start();
+
+            String repositoryUrl = server.url("/api/repos/" + owner + "/" + repository).toString();
+
+            FileContentLoader contentLoader = new FileContentLoader("userAgent");
+
+            Mockito.when(accessToken.get()).thenReturn("token authToken12345");
+
+            try {
+                Optional<String> result = contentLoader.loadContents(accessToken, repositoryUrl, ref, path);
+
+                Assert.assertNotNull(result);
+                Assert.assertFalse(result.isPresent());
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 1);
+                RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request.getHeader("User-Agent"), "userAgent");
+                Assert.assertEquals(request.getHeader("Accept"), MediaTypes.APP_PREVIEW);
+                Assert.assertEquals(request.getHeader("Authorization"), "token authToken12345");
+                Assert.assertEquals(request.getPath(),
+                        "/api/repos/" + owner + "/" + repository + "/contents/" + path + "?ref=" + ref);
+
+                Mockito.verify(accessToken).get();
+            }
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void loadContentUnexpectedEncoding() throws Exception {
+        String responseJson = null;
+
+        try (BufferedReader reader = getClasspathReader(
+                TEST_RESOURCE_FOLDER.resolve("fileContentUnsupportedEncodingResponse.json"))) {
+            responseJson = reader.lines()
+                    .collect(Collectors.joining("\n"));
+        }
+
+        MockResponse response = new MockResponse()
+                .addHeader("Content-Type", MediaTypes.APP_PREVIEW)
+                .setBody(responseJson);
+
+        String owner = "owner";
+        String repository = "repository";
+        String ref = "ref";
+        String path = "path.json";
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(response);
+            server.start();
+
+            String repositoryUrl = server.url("/api/repos/" + owner + "/" + repository).toString();
+
+            FileContentLoader contentLoader = new FileContentLoader("userAgent");
+
+            Mockito.when(accessToken.get()).thenReturn("token authToken12345");
+
+            try {
+                contentLoader.loadContents(accessToken, repositoryUrl, ref, path);
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 1);
+                RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request.getHeader("User-Agent"), "userAgent");
+                Assert.assertEquals(request.getHeader("Accept"), MediaTypes.APP_PREVIEW);
+                Assert.assertEquals(request.getHeader("Authorization"), "token authToken12345");
+                Assert.assertEquals(request.getPath(),
+                        "/api/repos/" + owner + "/" + repository + "/contents/" + path + "?ref=" + ref);
+
+                Mockito.verify(accessToken).get();
+            }
+        }
+    }
+
+    @Test
+    public void loadContents() throws Exception {
+        String responseJson = null;
+
+        try (BufferedReader reader = getClasspathReader(TEST_RESOURCE_FOLDER.resolve("fileContentResponse.json"))) {
+            responseJson = reader.lines()
+                    .collect(Collectors.joining("\n"));
+        }
+
+        MockResponse response = new MockResponse()
+                .addHeader("Content-Type", MediaTypes.APP_PREVIEW)
+                .setBody(responseJson);
+
+        String owner = "owner";
+        String repository = "repository";
+        String ref = "ref";
+        String path = "path.json";
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(response);
+            server.start();
+
+            String repositoryUrl = server.url("/api/repos/" + owner + "/" + repository).toString();
+
+            FileContentLoader contentLoader = new FileContentLoader("userAgent");
+
+            Mockito.when(accessToken.get()).thenReturn("token authToken12345");
+
+            try {
+                Optional<String> result = contentLoader.loadContents(accessToken, repositoryUrl, ref, path);
+
+                Assert.assertNotNull(result);
+                Assert.assertTrue(result.isPresent());
+                Assert.assertEquals(result.get(), "This is test text");
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 1);
+                RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request.getHeader("User-Agent"), "userAgent");
+                Assert.assertEquals(request.getHeader("Accept"), MediaTypes.APP_PREVIEW);
+                Assert.assertEquals(request.getHeader("Authorization"), "token authToken12345");
+                Assert.assertEquals(request.getPath(),
+                        "/api/repos/" + owner + "/" + repository + "/contents/" + path + "?ref=" + ref);
+
+                Mockito.verify(accessToken).get();
+            }
+        }
+    }
+
+    @Test
+    public void loadContentsMimeEncoding() throws Exception {
+        String responseJson = null;
+        String expectedContents = "productionFiles:\n" +
+                "   include:\n" +
+                "      - '**/README*'\n" +
+                "releaseNoteFiles:\n" +
+                "   include:\n" +
+                "      - '**/CHANGE*LOG*'\n" +
+                "      - '**/RELEASE*NOTES*'\n";
+
+        try (BufferedReader reader = getClasspathReader(
+                TEST_RESOURCE_FOLDER.resolve("fileContentResponseMimeEncoding.json"))) {
+            responseJson = reader.lines()
+                    .collect(Collectors.joining("\n"));
+        }
+
+        MockResponse response = new MockResponse()
+                .addHeader("Content-Type", MediaTypes.APP_PREVIEW)
+                .setBody(responseJson);
+
+        String owner = "owner";
+        String repository = "repository";
+        String ref = "ref";
+        String path = "path.json";
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(response);
+            server.start();
+
+            String repositoryUrl = server.url("/api/repos/" + owner + "/" + repository).toString();
+
+            FileContentLoader contentLoader = new FileContentLoader("userAgent");
+
+            Mockito.when(accessToken.get()).thenReturn("token authToken12345");
+
+            try {
+                Optional<String> result = contentLoader.loadContents(accessToken, repositoryUrl, ref, path);
+
+                Assert.assertNotNull(result);
+                Assert.assertTrue(result.isPresent());
+                Assert.assertEquals(result.get(), expectedContents);
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 1);
+                RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request.getHeader("User-Agent"), "userAgent");
+                Assert.assertEquals(request.getHeader("Accept"), MediaTypes.APP_PREVIEW);
+                Assert.assertEquals(request.getHeader("Authorization"), "token authToken12345");
+                Assert.assertEquals(request.getPath(),
+                        "/api/repos/" + owner + "/" + repository + "/contents/" + path + "?ref=" + ref);
+
+                Mockito.verify(accessToken).get();
+            }
+        }
+    }
+
+    private BufferedReader getClasspathReader(Path filePath) {
+        return new BufferedReader(
+                new InputStreamReader(getClass().getClassLoader().getResourceAsStream(filePath.toString()),
+                        StandardCharsets.UTF_8));
+    }
+
+}

--- a/calamari-core/src/test/resources/org/starchartlabs/calamari/test/core/content/fileContentResponse.json
+++ b/calamari-core/src/test/resources/org/starchartlabs/calamari/test/core/content/fileContentResponse.json
@@ -1,0 +1,18 @@
+{
+  "type": "file",
+  "encoding": "base64",
+  "size": 5362,
+  "name": "README.md",
+  "path": "README.md",
+  "content": "VGhpcyBpcyB0ZXN0IHRleHQ=",
+  "sha": "3d21ec53a331a6f037a91c368710b99387d012c1",
+  "url": "https://api.github.com/repos/octokit/octokit.rb/contents/README.md",
+  "git_url": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+  "html_url": "https://github.com/octokit/octokit.rb/blob/master/README.md",
+  "download_url": "https://raw.githubusercontent.com/octokit/octokit.rb/master/README.md",
+  "_links": {
+    "git": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+    "self": "https://api.github.com/repos/octokit/octokit.rb/contents/README.md",
+    "html": "https://github.com/octokit/octokit.rb/blob/master/README.md"
+  }
+}

--- a/calamari-core/src/test/resources/org/starchartlabs/calamari/test/core/content/fileContentResponseMimeEncoding.json
+++ b/calamari-core/src/test/resources/org/starchartlabs/calamari/test/core/content/fileContentResponseMimeEncoding.json
@@ -1,0 +1,18 @@
+{
+  "type": "file",
+  "encoding": "base64",
+  "size": 5362,
+  "name": "README.md",
+  "path": "README.md",
+  "content": "cHJvZHVjdGlvbkZpbGVzOgogICBpbmNsdWRlOgogICAgICAtICcqKi9SRUFETUUqJwpyZWxlYXNlTm90ZUZpbGVzOgogICBpbmNsdWRlOgogICAgICAtICcqKi9DSEFOR0UqTE9HKicKICAgICAgLSAnKiovUkVMRUFTRSpOT1RFUyonCg==",
+  "sha": "3d21ec53a331a6f037a91c368710b99387d012c1",
+  "url": "https://api.github.com/repos/octokit/octokit.rb/contents/README.md",
+  "git_url": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+  "html_url": "https://github.com/octokit/octokit.rb/blob/master/README.md",
+  "download_url": "https://raw.githubusercontent.com/octokit/octokit.rb/master/README.md",
+  "_links": {
+    "git": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+    "self": "https://api.github.com/repos/octokit/octokit.rb/contents/README.md",
+    "html": "https://github.com/octokit/octokit.rb/blob/master/README.md"
+  }
+}

--- a/calamari-core/src/test/resources/org/starchartlabs/calamari/test/core/content/fileContentUnsupportedEncodingResponse.json
+++ b/calamari-core/src/test/resources/org/starchartlabs/calamari/test/core/content/fileContentUnsupportedEncodingResponse.json
@@ -1,0 +1,18 @@
+{
+  "type": "file",
+  "encoding": "base56",
+  "size": 5362,
+  "name": "README.md",
+  "path": "README.md",
+  "content": "VGhpcyBpcyB0ZXN0IHRleHQ=",
+  "sha": "3d21ec53a331a6f037a91c368710b99387d012c1",
+  "url": "https://api.github.com/repos/octokit/octokit.rb/contents/README.md",
+  "git_url": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+  "html_url": "https://github.com/octokit/octokit.rb/blob/master/README.md",
+  "download_url": "https://raw.githubusercontent.com/octokit/octokit.rb/master/README.md",
+  "_links": {
+    "git": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+    "self": "https://api.github.com/repos/octokit/octokit.rb/contents/README.md",
+    "html": "https://github.com/octokit/octokit.rb/blob/master/README.md"
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Application Versions
-version=0.2.2-SNAPSHOT
+version=0.3.0-SNAPSHOT
 
 # Consumed Language/Build System Versions
 # TODO romeara - upgrading to 4.5.1 breaks the Jacoco report merge plug-in


### PR DESCRIPTION
Add FileContentLoader, which handles the general GitHub App flow
required to read and decode text-based file content from GitHub