### PR TITLE
Add support for reading GitHub paged data in a fluent manner

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Added org.starchartlabs.calamari.core.content.ConfigurationFileLoader for reading configuration file contents from GitHub
+- Added org.starchartlabs.calamari.core.paging.PagingLinks to represent GitHub paging links
+- Added org.starchartlabs.calamari.core.paging.GitHubPageIterator<T> to allow traversal of GitHub paged data
 
 ## [0.2.1]
 ### Fixed

--- a/calamari-core/src/main/java/org/starchartlabs/calamari/core/exception/GitHubResponseException.java
+++ b/calamari-core/src/main/java/org/starchartlabs/calamari/core/exception/GitHubResponseException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.calamari.core.exception;
+
+/**
+ * Represents an error during the process of communicating with GitHub APIs
+ *
+ * @author romeara
+ * @since 0.3.0
+ */
+public class GitHubResponseException extends RuntimeException {
+
+    private static final long serialVersionUID = 1702104867544399789L;
+
+    /**
+     * @param message
+     *            Description of the exceptional condition which could not be recovered from
+     * @since 0.3.0
+     */
+    public GitHubResponseException(String message) {
+        super(message);
+    }
+
+    /**
+     * @param message
+     *            Description of the exceptional condition which could not be recovered from
+     * @param cause
+     *            The root cause of the error
+     * @since 0.3.0
+     */
+    public GitHubResponseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/calamari-core/src/main/java/org/starchartlabs/calamari/core/paging/GitHubPageIterator.java
+++ b/calamari-core/src/main/java/org/starchartlabs/calamari/core/paging/GitHubPageIterator.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.calamari.core.paging;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.starchartlabs.alloy.core.collections.MoreSpliterators;
+import org.starchartlabs.alloy.core.collections.PageIterator;
+import org.starchartlabs.calamari.core.MediaTypes;
+import org.starchartlabs.calamari.core.ResponseConditions;
+import org.starchartlabs.calamari.core.exception.GitHubResponseException;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+/**
+ * An implementation of {@link PageIterator} for traversing paged data read from GitHub APIs
+ *
+ * <p>
+ * Allows mapping of read elements at the Iterator level to prevent overhead in later steps
+ *
+ * <p>
+ * Uses paging links to estimate remaining size
+ *
+ * <p>
+ * See {@link MoreSpliterators#ofPaged(PageIterator)} for a path to consuming paged data as a Java Stream via
+ * spliterator
+ *
+ * @author romeara
+ *
+ * @param <T>
+ *            Type representing an individual paged element
+ * @since 0.3.0
+ * @see MoreSpliterators#ofPaged(PageIterator)
+ */
+public class GitHubPageIterator<T> implements PageIterator<T> {
+
+    private final Supplier<String> authorizationHeader;
+
+    private final String userAgent;
+
+    private final JsonArrayConverter<?, T> itemMapper;
+
+    private final OkHttpClient httpClient;
+
+    private String url;
+
+    private String mediaType;
+
+    private Optional<Long> remainingEstimate;
+
+    /**
+     * Creates a new {@link GitHubPageIterator}
+     *
+     * @param url
+     *            The initial URL to request paged data from
+     * @param authorizationHeader
+     *            Supplier which provides contents for the {@code Authorization} header when making requests
+     * @param userAgent
+     *            The user agent to make web requests as, as
+     *            <a href="https://developer.github.com/v3/#user-agent-required">required by GitHub</a>
+     * @param jsonDeserializer
+     *            Function which transforms a raw JSON response representing a full page into individual data elements
+     * @since 0.3.0
+     */
+    public GitHubPageIterator(String url, Supplier<String> authorizationHeader, String userAgent,
+            Function<String, Collection<T>> jsonDeserializer) {
+        this(url, authorizationHeader, userAgent, new JsonArrayConverter<>(jsonDeserializer, Function.identity()),
+                MediaTypes.APP_PREVIEW);
+    }
+
+    /**
+     * Creates a new {@link GitHubPageIterator}
+     *
+     * @param url
+     *            The initial URL to request paged data from
+     * @param authorizationHeader
+     *            Supplier which provides contents for the {@code Authorization} header when making requests
+     * @param userAgent
+     *            The user agent to make web requests as, as
+     *            <a href="https://developer.github.com/v3/#user-agent-required">required by GitHub</a>
+     * @param jsonDeserializer
+     *            Function which transforms a raw JSON response representing a full page into individual data elements
+     * @param mediaType
+     *            The media type to request from the server via {@code Accept} header
+     * @since 0.3.0
+     */
+    public GitHubPageIterator(String url, Supplier<String> authorizationHeader, String userAgent,
+            Function<String, Collection<T>> jsonDeserializer, String mediaType) {
+        this(url, authorizationHeader, userAgent, new JsonArrayConverter<>(jsonDeserializer, Function.identity()),
+                mediaType);
+    }
+
+    /**
+     * Creates a new {@link GitHubPageIterator}
+     *
+     * @param url
+     *            The initial URL to request paged data from
+     * @param authorizationHeader
+     *            Supplier which provides contents for the {@code Authorization} header when making requests
+     * @param userAgent
+     *            The user agent to make web requests as, as
+     *            <a href="https://developer.github.com/v3/#user-agent-required">required by GitHub</a>
+     * @param itemMapper
+     *            Function which transforms page elements to the representation desired by clients
+     * @param mediaType
+     *            The media type to request from the server via {@code Accept} header
+     */
+    private GitHubPageIterator(String url, Supplier<String> authorizationHeader, String userAgent,
+            JsonArrayConverter<?, T> itemMapper, String mediaType) {
+        this.authorizationHeader = Objects.requireNonNull(authorizationHeader);
+        this.userAgent = Objects.requireNonNull(userAgent);
+        this.url = Objects.requireNonNull(url);
+        this.itemMapper = Objects.requireNonNull(itemMapper);
+        this.mediaType = Objects.requireNonNull(mediaType);
+
+        httpClient = new OkHttpClient();
+        remainingEstimate = Optional.empty();
+    }
+
+    /**
+     * Transforms each element of paged data encountered via the provided function
+     *
+     * @param mapperPerElement
+     *            Function to apply to each element representation, for transforming from the current element
+     *            representation to a new one
+     * @param <S>
+     *            New type representing an individual paged element
+     * @return A GitHubPageInterator which will provide elements as the desired representation
+     * @since 0.3.0
+     */
+    public <S> GitHubPageIterator<S> map(Function<T, S> mapperPerElement) {
+        Objects.requireNonNull(mapperPerElement);
+
+        return new GitHubPageIterator<>(url, authorizationHeader, userAgent, itemMapper.andThenEach(mapperPerElement));
+    }
+
+    @Override
+    public boolean hasNext() {
+        return url != null;
+    }
+
+    @Override
+    public Collection<T> next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException("No more pages may be read from the provided GitHub endpoint");
+        }
+
+        try {
+            // Populate next set of elements, if possible
+            Response response = getResponse(url);
+
+            if (!response.isSuccessful()) {
+                ResponseConditions.checkRateLimit(response);
+
+                throw new GitHubResponseException("Response returned unsuccessfully (" + response.code() + ")");
+            }
+
+            // Update tracking of paging position (URL and paging links)
+            PagingLinks pagingLinks = new PagingLinks(response.headers("Link"));
+            url = pagingLinks.getNextPageUrl().orElse(null);
+
+            remainingEstimate = estimateRemaining(pagingLinks);
+
+            // Update cache of previously read elements, which will be read from until the next page is needed
+            try (ResponseBody responseBody = response.body()) {
+                return itemMapper.apply(responseBody.string());
+            }
+        } catch (IOException e) {
+            throw new GitHubResponseException("Error reading response from GitHub", e);
+        }
+    }
+
+    @Override
+    public PageIterator<T> trySplit() {
+        // TODO romeara Implementation of this will require further investigation
+        // At minimum, logic to allow ending the iteration before a "next" link is absent would be needed in order to
+        // sub-divide pages. For a first implementation iteration, this will be kept simpler and less bug-prone by not
+        // allowing splitting
+        return null;
+    }
+
+    @Override
+    public long estimateSize() {
+        return remainingEstimate
+                .orElse(Long.MAX_VALUE);
+    }
+
+    /**
+     * Creates a new {@link GitHubPageIterator} configured to extract paged elements into Gson {@link JsonElement}
+     * instances
+     *
+     * @param url
+     *            The initial URL to request paged data from
+     * @param authorizationHeader
+     *            Supplier which provides contents for the {@code Authorization} header when making requests
+     * @param userAgent
+     *            The user agent to make web requests as, as
+     *            <a href="https://developer.github.com/v3/#user-agent-required">required by GitHub</a>
+     * @return A GitHubPageIterator which allows iteration over elements as JsonElement instances
+     * @since 0.3.0
+     */
+    public static GitHubPageIterator<JsonElement> gson(String url, Supplier<String> authorizationHeader,
+            String userAgent) {
+        return new GitHubPageIterator<>(url, authorizationHeader, userAgent, new JsonElementConverter());
+    }
+
+    /**
+     * Creates a new {@link GitHubPageIterator} configured to extract paged elements into Gson {@link JsonElement}
+     * instances
+     *
+     * @param url
+     *            The initial URL to request paged data from
+     * @param authorizationHeader
+     *            Supplier which provides contents for the {@code Authorization} header when making requests
+     * @param userAgent
+     *            The user agent to make web requests as, as
+     *            <a href="https://developer.github.com/v3/#user-agent-required">required by GitHub</a>
+     * @param mediaType
+     *            The media type to request from the server via {@code Accept} header
+     * @return A GitHubPageIterator which allows iteration over elements as JsonElement instances
+     * @since 0.3.0
+     */
+    public static GitHubPageIterator<JsonElement> gson(String url, Supplier<String> authorizationHeader,
+            String userAgent, String mediaType) {
+        return new GitHubPageIterator<>(url, authorizationHeader, userAgent, new JsonElementConverter(), mediaType);
+    }
+
+    /**
+     * Generates and executes a request to the provided URL with the configured user agent, media type, and
+     * authorization header
+     *
+     * @param url
+     *            The URL to make a request to
+     * @return Representation of the response provided from the server
+     * @throws IOException
+     *             If there is an issue making the request to the server (connection issue, timeout, etc)
+     */
+    private Response getResponse(String url) throws IOException {
+        Objects.requireNonNull(url);
+
+        Request request = new Request.Builder()
+                .get()
+                .header("User-Agent", userAgent)
+                .header("Accept", mediaType)
+                .header("Authorization", authorizationHeader.get())
+                .url(url)
+                .build();
+
+        return httpClient.newCall(request).execute();
+    }
+
+    /**
+     * Estimates the maximum number of elements which may be remaining based on the page read and the next page to read
+     *
+     * <p>
+     * This function notable over-estimates - it provides the maximum possible number of elements, assuming that even
+     * the last page will contain exactly as many elements as were request per-page
+     *
+     * @param pagingLinks
+     *            Representation of the GitHub links used to traverse paged responses
+     * @return A high-ball estimate of the remaining elements, or empty if not enough information is available to make a
+     *         reasonable estimate
+     */
+    private Optional<Long> estimateRemaining(PagingLinks pagingLinks) {
+        Objects.requireNonNull(pagingLinks);
+
+        Integer result = null;
+
+        if (hasNext()) {
+            Optional<Integer> perPage = Optional.ofNullable(pagingLinks)
+                    .flatMap(PagingLinks::getNextPageUrl)
+                    .flatMap(PagingLinks::getPerPage);
+
+            Optional<Integer> nextPageNumber = Optional.ofNullable(pagingLinks)
+                    .flatMap(PagingLinks::getNextPageUrl)
+                    .flatMap(PagingLinks::getPage);
+
+            Optional<Integer> lastPageNumber = Optional.ofNullable(pagingLinks)
+                    .flatMap(PagingLinks::getLastPageUrl)
+                    .flatMap(PagingLinks::getPage);
+
+            if (perPage.isPresent() && nextPageNumber.isPresent() && lastPageNumber.isPresent()) {
+                // The plus one accounts for having not read the next page
+                int pagesRemaining = lastPageNumber.get() - nextPageNumber.get() + 1;
+
+                result = pagesRemaining * perPage.get();
+            }
+        } else {
+            result = 0;
+        }
+
+        return Optional.ofNullable(result).map(Integer::longValue);
+    }
+
+    /**
+     * Function implementation which allows chaining of additional functions to transform the individual elements of a
+     * paged response
+     *
+     * @author romeara
+     *
+     * @param <S>
+     *            The starting representation of a given element
+     * @param <T>
+     *            The current provided implementation of the given element
+     */
+    private static final class JsonArrayConverter<S, T> implements Function<String, Collection<T>> {
+
+        private final Function<String, Collection<S>> jsonDeserializer;
+
+        private final Function<S, T> mapperPerElement;
+
+        public JsonArrayConverter(Function<String, Collection<S>> jsonDeserializer, Function<S, T> mapperPerElement) {
+            this.jsonDeserializer = Objects.requireNonNull(jsonDeserializer);
+            this.mapperPerElement = Objects.requireNonNull(mapperPerElement);
+        }
+
+        @Override
+        public Collection<T> apply(String json) {
+            return jsonDeserializer.apply(json).stream()
+                    .map(mapperPerElement)
+                    .collect(Collectors.toList());
+        }
+
+        public <U> JsonArrayConverter<S, U> andThenEach(Function<T, U> mapperPerElement) {
+            return new JsonArrayConverter<>(jsonDeserializer, this.mapperPerElement.andThen(mapperPerElement));
+        }
+
+    }
+
+    /**
+     * Converter used in {@link GitHubPageIterator#gson(String, Supplier, String)} call to support basic conversion from
+     * JSON string to JSON elements from the array
+     *
+     * <p>
+     * A full implementation is provided to avoid re-instantiating an instance of {@link Gson} every invocation
+     *
+     * @author romeara
+     */
+    private static final class JsonElementConverter implements Function<String, Collection<JsonElement>> {
+
+        private Gson gson;
+
+        public JsonElementConverter() {
+            gson = new GsonBuilder().create();
+        }
+
+        @Override
+        public Collection<JsonElement> apply(String json) {
+            JsonElement element = gson.fromJson(json, JsonElement.class);
+
+            return StreamSupport.stream(element.getAsJsonArray().spliterator(), false)
+                    .collect(Collectors.toList());
+        }
+
+    }
+
+}

--- a/calamari-core/src/main/java/org/starchartlabs/calamari/core/paging/PagingLinks.java
+++ b/calamari-core/src/main/java/org/starchartlabs/calamari/core/paging/PagingLinks.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.calamari.core.paging;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.starchartlabs.alloy.core.MoreObjects;
+
+import okhttp3.HttpUrl;
+
+/**
+ * Handles parsing of GitHub paging headers into distinct links for traversal of paged data
+ *
+ * <p>
+ * GitHub does not provide all headers on all returns. The first page only contains the "next" and "last" links. The
+ * last page only contains the "first" and "prev" links. All other pages contain all four headers. If there is only one
+ * page of data, none of the links are returned
+ *
+ * <p>
+ * Based on <a href="https://developer.github.com/v3/#pagination">GitHub pagination documentation</a>
+ *
+ * @author romeara
+ * @since 0.3.0
+ */
+public class PagingLinks {
+
+    // Pattern which matches link header format returned by GitHub and allows extraction of the URL and rel key
+    // Example value: <https://api.github.com/user/repos?page=1&per_page=100>; rel="first"
+    // Example extraction: https://api.github.com/user/repos?page=1&per_page=100, first
+    private static final Pattern LINK_PATTERN = Pattern
+            .compile("\\A.*<([A-Za-z0-9\\-._~:/?#\\[\\]@!$&'()*+,;=%]*)>; rel=\"([A-Za-z0-9]*)\"");
+
+    private static final String FIRST_PAGE_REL = "first";
+
+    private static final String PREVIOUS_PAGE_REL = "prev";
+
+    private static final String NEXT_PAGE_REL = "next";
+
+    private static final String LAST_PAGE_REL = "last";
+
+    private static final String PAGE_PARAMETER = "page";
+
+    private static final String PER_PAGE_PARAMETER = "per_page";
+
+    /** Logger reference to output information to the application log files */
+    private static final Logger logger = LoggerFactory.getLogger(PagingLinks.class);
+
+    private final Optional<String> firstPageUrl;
+
+    private final Optional<String> previousPageUrl;
+
+    private final Optional<String> nextPageUrl;
+
+    private final Optional<String> lastPageUrl;
+
+    /**
+     * Parses one or more paging links from GitHub response headers
+     *
+     * @param links
+     *            One or more "Link" header values. Supports separated headers and headers contains a CSV of multiple
+     *            link entries
+     * @since 0.3.0
+     */
+    public PagingLinks(Collection<String> links) {
+        Objects.requireNonNull(links);
+
+        logger.debug("Link Headers: {}", links);
+
+        String firstUrl = null;
+        String prevUrl = null;
+        String nextUrl = null;
+        String lastUrl = null;
+
+        Collection<String> allLinks = links.stream()
+                .flatMap(s -> Arrays.asList(s.split(",")).stream())
+                .map(String::trim)
+                .collect(Collectors.toSet());
+
+        for (String link : allLinks) {
+            Matcher matcher = LINK_PATTERN.matcher(link);
+
+            if (matcher.matches()) {
+                String href = matcher.group(1);
+                String rel = matcher.group(2);
+
+                if (Objects.equals(rel, FIRST_PAGE_REL)) {
+                    firstUrl = href;
+                } else if (Objects.equals(rel, PREVIOUS_PAGE_REL)) {
+                    prevUrl = href;
+                } else if (Objects.equals(rel, NEXT_PAGE_REL)) {
+                    nextUrl = href;
+                } else if (Objects.equals(rel, LAST_PAGE_REL)) {
+                    lastUrl = href;
+                }
+            }
+        }
+
+        firstPageUrl = Optional.ofNullable(firstUrl);
+        previousPageUrl = Optional.ofNullable(prevUrl);
+        nextPageUrl = Optional.ofNullable(nextUrl);
+        lastPageUrl = Optional.ofNullable(lastUrl);
+    }
+
+    /**
+     * @return URL to the first set of data in a paged sequence. Only present if the response providing the links was
+     *         not the first page
+     * @since 0.3.0
+     */
+    public Optional<String> getFirstPageUrl() {
+        return firstPageUrl;
+    }
+
+    /**
+     * @return URL to the previous set of data in a paged sequence. Only present if the response providing the links was
+     *         not the first page
+     * @since 0.3.0
+     */
+    public Optional<String> getPreviousPageUrl() {
+        return previousPageUrl;
+    }
+
+    /**
+     * @return URL to the next set of data in a paged sequence. Only present if the response providing the links was not
+     *         the last page
+     * @since 0.3.0
+     */
+    public Optional<String> getNextPageUrl() {
+        return nextPageUrl;
+    }
+
+    /**
+     * @return URL to the last set of data in a paged sequence. Only present if the response providing the links was not
+     *         the last page
+     * @since 0.3.0
+     */
+    public Optional<String> getLastPageUrl() {
+        return lastPageUrl;
+    }
+
+    /**
+     * Reads the page index from a link. Page's are 1-indexed
+     *
+     * @param url
+     *            The link URL to read page information from
+     * @return The page index, or empty if no valid per-page specification was found
+     * @since 0.3.0
+     */
+    public static Optional<Integer> getPage(String url) {
+        Objects.requireNonNull(url);
+
+        return Optional.ofNullable(HttpUrl.get(url).queryParameter(PAGE_PARAMETER))
+                .flatMap(PagingLinks::getInteger);
+    }
+
+    /**
+     * Reads the number of elements request per-page from a link
+     *
+     * @param url
+     *            The link URL to read per-page information from
+     * @return The number of elements per page, or empty if no valid per-page specification was found
+     * @since 0.3.0
+     */
+    public static Optional<Integer> getPerPage(String url) {
+        Objects.requireNonNull(url);
+
+        return Optional.ofNullable(HttpUrl.get(url).queryParameter(PER_PAGE_PARAMETER))
+                .flatMap(PagingLinks::getInteger);
+    }
+
+    /**
+     * Converts a URL parameter expected to be an integer, if possible
+     *
+     * @param candidate
+     *            String to convert
+     * @return The integer value, or empty if the provided string was non-numeric
+     */
+    private static Optional<Integer> getInteger(String candidate) {
+        Objects.requireNonNull(candidate);
+
+        Integer result = null;
+
+        try {
+            result = Integer.valueOf(candidate);
+        }catch(NumberFormatException e) {
+            // The way this function is used, this should not occur
+            logger.warn("Non-numeric parameter value encountered: {}", candidate);
+        }
+
+        return Optional.ofNullable(result);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getFirstPageUrl(),
+                getPreviousPageUrl(),
+                getNextPageUrl(),
+                getLastPageUrl());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof PagingLinks) {
+            PagingLinks compare = (PagingLinks) obj;
+
+            result = Objects.equals(compare.getFirstPageUrl(), getFirstPageUrl())
+                    && Objects.equals(compare.getPreviousPageUrl(), getPreviousPageUrl())
+                    && Objects.equals(compare.getNextPageUrl(), getNextPageUrl())
+                    && Objects.equals(compare.getLastPageUrl(), getLastPageUrl());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("firstPageUrl", getFirstPageUrl())
+                .add("previousPageUrl", getPreviousPageUrl())
+                .add("nextPageUrl", getNextPageUrl())
+                .add("lastPageUrl", getLastPageUrl())
+                .toString();
+    }
+
+}

--- a/calamari-core/src/test/java/org/starchartlabs/calamari/test/LinkHeaderTestSupport.java
+++ b/calamari-core/src/test/java/org/starchartlabs/calamari/test/LinkHeaderTestSupport.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.calamari.test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import okhttp3.mockwebserver.MockWebServer;
+
+/**
+ * Provides supporting operations for streamlining dynamic tests related to GitHub paging links
+ *
+ * @author romeara
+ * @since 0.3.0
+ */
+public final class LinkHeaderTestSupport {
+
+    private static final String FIRST_PAGE_REL = "first";
+
+    private static final String PREV_PAGE_REL = "prev";
+
+    private static final String NEXT_PAGE_REL = "next";
+
+    private static final String LAST_PAGE_REL = "last";
+
+    private static final String PAGE_PARAMETER = "page";
+
+    private static final String PER_PAGE_PARAMETER = "per_page";
+
+    /**
+     * Prevent instantiation of utility class
+     */
+    private LinkHeaderTestSupport() throws InstantiationException {
+        throw new InstantiationException("Cannot instantiate instance of utility class '" + getClass().getName() + "'");
+    }
+
+    public static Collection<String> getLinkHeaders(MockWebServer server, String path, int currentPage, int maxPage,
+            int perPage) {
+        Collection<String> result = new ArrayList<>();
+
+        if (currentPage > 1) {
+            int firstPage = 1;
+            int previousPage = currentPage - 1;
+
+            String firstPageLink = server.url(path).newBuilder()
+                    .addQueryParameter(PAGE_PARAMETER, Integer.toString(firstPage))
+                    .addQueryParameter(PER_PAGE_PARAMETER, Integer.toString(perPage))
+                    .build()
+                    .toString();
+
+            String previousPageLink = server.url(path).newBuilder()
+                    .addQueryParameter(PAGE_PARAMETER, Integer.toString(previousPage))
+                    .addQueryParameter(PER_PAGE_PARAMETER, Integer.toString(perPage))
+                    .build()
+                    .toString();
+
+            result.add(getLinkHeader(firstPageLink, FIRST_PAGE_REL));
+            result.add(getLinkHeader(previousPageLink, PREV_PAGE_REL));
+        }
+
+        if (currentPage < maxPage) {
+            int nextPage = currentPage + 1;
+            int lastPage = maxPage;
+
+            String nextPageLink = server.url(path).newBuilder()
+                    .addQueryParameter(PAGE_PARAMETER, Integer.toString(nextPage))
+                    .addQueryParameter(PER_PAGE_PARAMETER, Integer.toString(perPage))
+                    .build()
+                    .toString();
+
+            String lastPageLink = server.url(path).newBuilder()
+                    .addQueryParameter(PAGE_PARAMETER, Integer.toString(lastPage))
+                    .addQueryParameter(PER_PAGE_PARAMETER, Integer.toString(perPage))
+                    .build()
+                    .toString();
+
+            result.add(getLinkHeader(nextPageLink, NEXT_PAGE_REL));
+            result.add(getLinkHeader(lastPageLink, LAST_PAGE_REL));
+        }
+
+        return result;
+    }
+
+    public static String getLinkHeader(String link, String rel) {
+        return "<" + link + ">; rel=\"" + rel + "\"";
+    }
+
+}

--- a/calamari-core/src/test/java/org/starchartlabs/calamari/test/core/paging/GitHubPageIteratorTest.java
+++ b/calamari-core/src/test/java/org/starchartlabs/calamari/test/core/paging/GitHubPageIteratorTest.java
@@ -1,0 +1,498 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.calamari.test.core.paging;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.starchartlabs.alloy.core.collections.PageIterator;
+import org.starchartlabs.calamari.core.MediaTypes;
+import org.starchartlabs.calamari.core.exception.GitHubResponseException;
+import org.starchartlabs.calamari.core.exception.RequestLimitExceededException;
+import org.starchartlabs.calamari.core.paging.GitHubPageIterator;
+import org.starchartlabs.calamari.test.LinkHeaderTestSupport;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.gson.JsonElement;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+public class GitHubPageIteratorTest {
+
+    private static final String RATE_LIMIT_REMAINING_HEADER = "X-RateLimit-Remaining";
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullUrl() throws Exception {
+        new GitHubPageIterator<String>(null, () -> "header", "userAgent", a -> Collections.singletonList(a),
+                "mediaType");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullAuthorizationHeader() throws Exception {
+        new GitHubPageIterator<String>("url", null, "userAgent", a -> Collections.singletonList(a), "mediaType");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullUserAgent() throws Exception {
+        new GitHubPageIterator<String>("url", () -> "header", null, a -> Collections.singletonList(a),
+                "mediaType");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullJsonDeserializer() throws Exception {
+        new GitHubPageIterator<String>("url", () -> "header", "userAgent", null, "mediaType");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullMediaType() throws Exception {
+        new GitHubPageIterator<String>("url", () -> "header", "userAgent", a -> Collections.singletonList(a),
+                null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void gsonNullUrl() throws Exception {
+        GitHubPageIterator.gson(null, () -> "header", "userAgent", "mediaType");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void gsonNullAuthorizationHeader() throws Exception {
+        GitHubPageIterator.gson("url", null, "userAgent", "mediaType");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void gsonNullUserAgent() throws Exception {
+        GitHubPageIterator.gson("url", () -> "header", null, "mediaType");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void gsonNullMediaType() throws Exception {
+        GitHubPageIterator.gson("url", () -> "header", "userAgent", null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void mapNullMapper() throws Exception {
+        GitHubPageIterator.gson("url", () -> "header", "userAgent")
+        .map(null);
+    }
+
+    @Test(expectedExceptions = GitHubResponseException.class)
+    public void nextErrorResponse() throws Exception {
+        MockResponse response = new MockResponse()
+                .setResponseCode(412);
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(response);
+            server.start();
+
+            String authorizationHeader = "header";
+            String userAgent = "userAgent";
+            String path = "/api/endpoint";
+
+            String url = server.url(path).toString();
+
+            GitHubPageIterator<String> iterator = new GitHubPageIterator<>(url, () -> authorizationHeader, userAgent,
+                    a -> Collections.singletonList(a));
+
+            try {
+                iterator.next();
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 1);
+                RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request.getHeader("User-Agent"), userAgent);
+                Assert.assertEquals(request.getHeader("Accept"), MediaTypes.APP_PREVIEW);
+                Assert.assertEquals(request.getHeader("Authorization"), authorizationHeader);
+                Assert.assertEquals(request.getPath(), path);
+            }
+        }
+    }
+
+    @Test(expectedExceptions = RequestLimitExceededException.class)
+    public void nextRequestLimitExceeded() throws Exception {
+        MockResponse response = new MockResponse()
+                .setResponseCode(403)
+                .addHeader(RATE_LIMIT_REMAINING_HEADER, "0");
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(response);
+            server.start();
+
+            String authorizationHeader = "header";
+            String userAgent = "userAgent";
+            String path = "/api/endpoint";
+
+            String url = server.url(path).toString();
+
+            GitHubPageIterator<String> iterator = new GitHubPageIterator<>(url, () -> authorizationHeader, userAgent,
+                    a -> Collections.singletonList(a));
+
+            try {
+                iterator.next();
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 1);
+                RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request.getHeader("User-Agent"), userAgent);
+                Assert.assertEquals(request.getHeader("Accept"), MediaTypes.APP_PREVIEW);
+                Assert.assertEquals(request.getHeader("Authorization"), authorizationHeader);
+                Assert.assertEquals(request.getPath(), path);
+            }
+        }
+    }
+
+    @Test(expectedExceptions = NoSuchElementException.class)
+    public void nextNoMoreElements() throws Exception {
+        MockResponse response = new MockResponse()
+                .addHeader("Content-Type", MediaTypes.APP_PREVIEW)
+                .setBody("[]");
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(response);
+            server.start();
+
+            String authorizationHeader = "header";
+            String userAgent = "userAgent";
+            String path = "/api/endpoint";
+
+            String url = server.url(path).toString();
+
+            GitHubPageIterator<?> iterator = GitHubPageIterator.gson(url, () -> authorizationHeader, userAgent);
+
+            // First should pass with original response
+            try {
+                iterator.next();
+            } catch (RuntimeException e) {
+                Assert.fail("First call should succeed, elements still remain", e);
+            }
+
+            try {
+                iterator.next();
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 1);
+                RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request.getHeader("User-Agent"), userAgent);
+                Assert.assertEquals(request.getHeader("Accept"), MediaTypes.APP_PREVIEW);
+                Assert.assertEquals(request.getHeader("Authorization"), authorizationHeader);
+                Assert.assertEquals(request.getPath(), path);
+            }
+        }
+    }
+
+    @Test
+    public void nextSinglePage() throws Exception {
+        // Single page has content and no links
+        MockResponse response = new MockResponse()
+                .addHeader("Content-Type", MediaTypes.APP_PREVIEW)
+                .setBody(getResponseContent("1", "2"));
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(response);
+            server.start();
+
+            String authorizationHeader = "header";
+            String userAgent = "userAgent";
+            String path = "/api/endpoint";
+
+            String url = server.url(path).toString();
+
+            GitHubPageIterator<String> iterator = GitHubPageIterator.gson(url, () -> authorizationHeader, userAgent)
+                    .map(JsonElement::getAsString);
+
+            // First should pass with original response
+            try {
+                Collection<String> result = iterator.next();
+
+                List<String> orderedResult = new ArrayList<>(result);
+
+                Assert.assertNotNull(result);
+                Assert.assertEquals(result.size(), 2);
+                Assert.assertEquals(orderedResult.get(0), "1");
+                Assert.assertEquals(orderedResult.get(1), "2");
+
+                Assert.assertFalse(iterator.hasNext());
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 1);
+                RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request.getHeader("User-Agent"), userAgent);
+                Assert.assertEquals(request.getHeader("Accept"), MediaTypes.APP_PREVIEW);
+                Assert.assertEquals(request.getHeader("Authorization"), authorizationHeader);
+                Assert.assertEquals(request.getPath(), path);
+            }
+        }
+    }
+
+    @Test
+    public void nextMultiplePages() throws Exception {
+        String path = "/api/endpoint";
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.start();
+
+            Collection<String> firstPageLinks = LinkHeaderTestSupport.getLinkHeaders(server, path, 1, 3, 2);
+            Collection<String> secondPageLinks = LinkHeaderTestSupport.getLinkHeaders(server, path, 2, 3, 2);
+            Collection<String> thirdPageLinks = LinkHeaderTestSupport.getLinkHeaders(server, path, 3, 3, 2);
+
+            MockResponse response1 = new MockResponse()
+                    .addHeader("Content-Type", MediaTypes.APP_PREVIEW)
+                    .setBody(getResponseContent("1", "2"));
+
+            firstPageLinks.forEach(link -> response1.addHeader("Link", link));
+
+            MockResponse response2 = new MockResponse()
+                    .addHeader("Content-Type", MediaTypes.APP_PREVIEW)
+                    .setBody(getResponseContent("3", "4"));
+
+            secondPageLinks.forEach(link -> response2.addHeader("Link", link));
+
+            MockResponse response3 = new MockResponse()
+                    .addHeader("Content-Type", MediaTypes.APP_PREVIEW)
+                    .setBody(getResponseContent("5", "6"));
+
+            thirdPageLinks.forEach(link -> response3.addHeader("Link", link));
+
+            server.enqueue(response1);
+            server.enqueue(response2);
+            server.enqueue(response3);
+
+            String authorizationHeader = "header";
+            String userAgent = "userAgent";
+
+            String url = server.url(path).toString();
+
+            GitHubPageIterator<String> iterator = GitHubPageIterator.gson(url, () -> authorizationHeader, userAgent)
+                    .map(JsonElement::getAsString);
+
+            // First should pass with original response
+            try {
+                Collection<String> result = iterator.next();
+                List<String> orderedResult = new ArrayList<>(result);
+
+                Assert.assertNotNull(result);
+                Assert.assertEquals(result.size(), 2);
+                Assert.assertEquals(orderedResult.get(0), "1");
+                Assert.assertEquals(orderedResult.get(1), "2");
+
+                Assert.assertTrue(iterator.hasNext());
+
+                result = iterator.next();
+                orderedResult = new ArrayList<>(result);
+
+                Assert.assertNotNull(result);
+                Assert.assertEquals(result.size(), 2);
+                Assert.assertEquals(orderedResult.get(0), "3");
+                Assert.assertEquals(orderedResult.get(1), "4");
+
+                Assert.assertTrue(iterator.hasNext());
+
+                result = iterator.next();
+                orderedResult = new ArrayList<>(result);
+
+                Assert.assertNotNull(result);
+                Assert.assertEquals(result.size(), 2);
+                Assert.assertEquals(orderedResult.get(0), "5");
+                Assert.assertEquals(orderedResult.get(1), "6");
+
+                Assert.assertFalse(iterator.hasNext());
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 3);
+                RecordedRequest request1 = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request1.getHeader("User-Agent"), userAgent);
+                Assert.assertEquals(request1.getHeader("Accept"), MediaTypes.APP_PREVIEW);
+                Assert.assertEquals(request1.getHeader("Authorization"), authorizationHeader);
+                Assert.assertEquals(request1.getPath(), path);
+
+                RecordedRequest request2 = server.takeRequest(2, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request2.getHeader("User-Agent"), userAgent);
+                Assert.assertEquals(request2.getHeader("Accept"), MediaTypes.APP_PREVIEW);
+                Assert.assertEquals(request2.getHeader("Authorization"), authorizationHeader);
+                Assert.assertEquals(request2.getPath(), path + "?page=2&per_page=2");
+
+                RecordedRequest request3 = server.takeRequest(3, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request3.getHeader("User-Agent"), userAgent);
+                Assert.assertEquals(request3.getHeader("Accept"), MediaTypes.APP_PREVIEW);
+                Assert.assertEquals(request3.getHeader("Authorization"), authorizationHeader);
+                Assert.assertEquals(request3.getPath(), path + "?page=3&per_page=2");
+            }
+        }
+    }
+
+    @Test
+    public void trySplit() throws Exception {
+        PageIterator<?> result = GitHubPageIterator.gson("url", () -> "header", "userAgent").trySplit();
+
+        // Currently, the GitHubPageIterator implementation does not support splitting
+        Assert.assertNull(result);
+    }
+
+    @Test
+    public void estimateSizeNoEstimate() throws Exception {
+        // Before paging is started, the implementation cannot meaningfully estimate the remaining elements
+        long result = GitHubPageIterator.gson("url", () -> "header", "userAgent").estimateSize();
+
+        Assert.assertEquals(result, Long.MAX_VALUE);
+    }
+
+    @Test
+    public void estimateSizeNoneRemaining() throws Exception {
+        MockResponse response = new MockResponse()
+                .addHeader("Content-Type", MediaTypes.APP_PREVIEW)
+                .setBody("[]");
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(response);
+            server.start();
+
+            String authorizationHeader = "header";
+            String userAgent = "userAgent";
+            String path = "/api/endpoint";
+
+            String url = server.url(path).toString();
+
+            GitHubPageIterator<?> iterator = GitHubPageIterator.gson(url, () -> authorizationHeader, userAgent);
+
+            // First should pass with original response
+            try {
+                iterator.next();
+
+                long result = iterator.estimateSize();
+
+                Assert.assertEquals(result, 0L);
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 1);
+                RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request.getHeader("User-Agent"), userAgent);
+                Assert.assertEquals(request.getHeader("Accept"), MediaTypes.APP_PREVIEW);
+                Assert.assertEquals(request.getHeader("Authorization"), authorizationHeader);
+                Assert.assertEquals(request.getPath(), path);
+            }
+        }
+    }
+
+    @Test
+    public void estimateSize() throws Exception {
+        String path = "/api/endpoint";
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.start();
+
+            Collection<String> firstPageLinks = LinkHeaderTestSupport.getLinkHeaders(server, path, 1, 2, 2);
+            Collection<String> secondPageLinks = LinkHeaderTestSupport.getLinkHeaders(server, path, 2, 2, 2);
+
+            MockResponse response1 = new MockResponse()
+                    .addHeader("Content-Type", MediaTypes.APP_PREVIEW)
+                    .setBody(getResponseContent("1", "2"));
+
+            firstPageLinks.forEach(link -> response1.addHeader("Link", link));
+
+            MockResponse response2 = new MockResponse()
+                    .addHeader("Content-Type", MediaTypes.APP_PREVIEW)
+                    .setBody(getResponseContent("3", "4"));
+
+            secondPageLinks.forEach(link -> response2.addHeader("Link", link));
+
+            server.enqueue(response1);
+            server.enqueue(response2);
+
+            String authorizationHeader = "header";
+            String userAgent = "userAgent";
+
+            String url = server.url(path).toString();
+
+            GitHubPageIterator<String> iterator = GitHubPageIterator.gson(url, () -> authorizationHeader, userAgent)
+                    .map(JsonElement::getAsString);
+
+            // First should pass with original response
+            try {
+                iterator.next();
+
+                long result = iterator.estimateSize();
+
+                Assert.assertEquals(result, 2L);
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 1);
+                RecordedRequest request1 = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request1.getHeader("User-Agent"), userAgent);
+                Assert.assertEquals(request1.getHeader("Accept"), MediaTypes.APP_PREVIEW);
+                Assert.assertEquals(request1.getHeader("Authorization"), authorizationHeader);
+                Assert.assertEquals(request1.getPath(), path);
+            }
+        }
+    }
+
+    @Test
+    public void estimateSizeEstimateOnPage() throws Exception {
+        String path = "/api/endpoint";
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.start();
+
+            Collection<String> firstPageLinks = LinkHeaderTestSupport.getLinkHeaders(server, path, 1, 2, 2);
+            Collection<String> secondPageLinks = LinkHeaderTestSupport.getLinkHeaders(server, path, 2, 2, 2);
+
+            MockResponse response1 = new MockResponse()
+                    .addHeader("Content-Type", MediaTypes.APP_PREVIEW)
+                    .setBody(getResponseContent("1", "2"));
+
+            firstPageLinks.forEach(link -> response1.addHeader("Link", link));
+
+            MockResponse response2 = new MockResponse()
+                    .addHeader("Content-Type", MediaTypes.APP_PREVIEW)
+                    .setBody(getResponseContent("3"));
+
+            secondPageLinks.forEach(link -> response2.addHeader("Link", link));
+
+            server.enqueue(response1);
+            server.enqueue(response2);
+
+            String authorizationHeader = "header";
+            String userAgent = "userAgent";
+
+            String url = server.url(path).toString();
+
+            GitHubPageIterator<String> iterator = GitHubPageIterator.gson(url, () -> authorizationHeader, userAgent)
+                    .map(JsonElement::getAsString);
+
+            // First should pass with original response
+            try {
+                iterator.next();
+
+                long result = iterator.estimateSize();
+
+                Assert.assertEquals(result, 2L);
+            } finally {
+                Assert.assertEquals(server.getRequestCount(), 1);
+                RecordedRequest request1 = server.takeRequest(1, TimeUnit.SECONDS);
+
+                Assert.assertEquals(request1.getHeader("User-Agent"), userAgent);
+                Assert.assertEquals(request1.getHeader("Accept"), MediaTypes.APP_PREVIEW);
+                Assert.assertEquals(request1.getHeader("Authorization"), authorizationHeader);
+                Assert.assertEquals(request1.getPath(), path);
+            }
+        }
+    }
+
+    private String getResponseContent(String... expected) {
+        return "[" + Stream.of(expected).map(v -> "\"" + v + "\"").collect(Collectors.joining(", ")) + "]";
+    }
+
+}

--- a/calamari-core/src/test/java/org/starchartlabs/calamari/test/core/paging/PagingLinksTest.java
+++ b/calamari-core/src/test/java/org/starchartlabs/calamari/test/core/paging/PagingLinksTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.calamari.test.core.paging;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.starchartlabs.calamari.core.paging.PagingLinks;
+import org.starchartlabs.calamari.test.LinkHeaderTestSupport;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PagingLinksTest {
+
+    private static final String FIRST_PAGE_LINK = "https://api.github.com/user/repos?page=1&per_page=100";
+
+    private static final String PREV_PAGE_LINK = "https://api.github.com/user/repos?page=2&per_page=100";
+
+    private static final String NEXT_PAGE_LINK = "https://api.github.com/user/repos?page=4&per_page=100";
+
+    private static final String LAST_PAGE_LINK = "https://api.github.com/user/repos?page=50&per_page=100";
+
+    private static final String FIRST_PAGE_HEADER = LinkHeaderTestSupport.getLinkHeader(FIRST_PAGE_LINK, "first");
+
+    private static final String PREV_PAGE_HEADER = LinkHeaderTestSupport.getLinkHeader(PREV_PAGE_LINK, "prev");
+
+    private static final String NEXT_PAGE_HEADER = LinkHeaderTestSupport.getLinkHeader(NEXT_PAGE_LINK, "next");
+
+    private static final String LAST_PAGE_HEADER = LinkHeaderTestSupport.getLinkHeader(LAST_PAGE_LINK, "last");
+
+    private static final String MULTIPLE_HEADERS = NEXT_PAGE_HEADER + ", " + LAST_PAGE_HEADER;
+
+    private static final String ALL_HEADERS = FIRST_PAGE_HEADER + ", " + PREV_PAGE_HEADER + ", " + NEXT_PAGE_HEADER
+            + ", " + LAST_PAGE_HEADER;
+
+    @Test
+    public void firstPageOnly() throws Exception {
+        PagingLinks result = new PagingLinks(Arrays.asList(FIRST_PAGE_HEADER));
+
+        Assert.assertEquals(result.getFirstPageUrl().get(), FIRST_PAGE_LINK);
+        Assert.assertFalse(result.getPreviousPageUrl().isPresent());
+        Assert.assertFalse(result.getLastPageUrl().isPresent());
+        Assert.assertFalse(result.getNextPageUrl().isPresent());
+    }
+
+    @Test
+    public void prevPageOnly() throws Exception {
+        PagingLinks result = new PagingLinks(Arrays.asList(PREV_PAGE_HEADER));
+
+        Assert.assertFalse(result.getFirstPageUrl().isPresent());
+        Assert.assertEquals(result.getPreviousPageUrl().get(), PREV_PAGE_LINK);
+        Assert.assertFalse(result.getLastPageUrl().isPresent());
+        Assert.assertFalse(result.getNextPageUrl().isPresent());
+    }
+
+    @Test
+    public void nextPageOnly() throws Exception {
+        PagingLinks result = new PagingLinks(Arrays.asList(NEXT_PAGE_HEADER));
+
+        Assert.assertFalse(result.getFirstPageUrl().isPresent());
+        Assert.assertFalse(result.getPreviousPageUrl().isPresent());
+        Assert.assertFalse(result.getLastPageUrl().isPresent());
+        Assert.assertEquals(result.getNextPageUrl().get(), NEXT_PAGE_LINK);
+    }
+
+    @Test
+    public void lastPageOnly() throws Exception {
+        PagingLinks result = new PagingLinks(Arrays.asList(LAST_PAGE_HEADER));
+
+        Assert.assertFalse(result.getFirstPageUrl().isPresent());
+        Assert.assertFalse(result.getPreviousPageUrl().isPresent());
+        Assert.assertFalse(result.getNextPageUrl().isPresent());
+        Assert.assertEquals(result.getLastPageUrl().get(), LAST_PAGE_LINK);
+    }
+
+    @Test
+    public void validLinkHeadersSingleEntry() throws Exception {
+        PagingLinks result = new PagingLinks(Arrays.asList(MULTIPLE_HEADERS));
+
+        Assert.assertFalse(result.getFirstPageUrl().isPresent());
+        Assert.assertFalse(result.getPreviousPageUrl().isPresent());
+        Assert.assertEquals(result.getNextPageUrl().get(), NEXT_PAGE_LINK);
+        Assert.assertEquals(result.getLastPageUrl().get(), LAST_PAGE_LINK);
+    }
+
+    @Test
+    public void validLinkHeadersMultiEntry() throws Exception {
+        PagingLinks result = new PagingLinks(Arrays.asList(NEXT_PAGE_HEADER, LAST_PAGE_HEADER));
+
+        Assert.assertFalse(result.getFirstPageUrl().isPresent());
+        Assert.assertFalse(result.getPreviousPageUrl().isPresent());
+        Assert.assertEquals(result.getNextPageUrl().get(), NEXT_PAGE_LINK);
+        Assert.assertEquals(result.getLastPageUrl().get(), LAST_PAGE_LINK);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void getPageNullUrl() throws Exception {
+        PagingLinks.getPage(null);
+    }
+
+    @Test
+    public void getPageNoParameter() throws Exception {
+        Optional<Integer> result = PagingLinks.getPage("https://api.github.com/user/repos");
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void getPageNonNumericValue() throws Exception {
+        Optional<Integer> result = PagingLinks.getPage("https://api.github.com/user/repos?page=blah");
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void getPage() throws Exception {
+        Optional<Integer> result = PagingLinks.getPage("https://api.github.com/user/repos?page=50");
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.isPresent());
+        Assert.assertEquals(result.get().intValue(), 50);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void getPerPageNullUrl() throws Exception {
+        PagingLinks.getPerPage(null);
+    }
+
+    @Test
+    public void getPerPageNoParameter() throws Exception {
+        Optional<Integer> result = PagingLinks.getPerPage("https://api.github.com/user/repos");
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void getPerPageNonNumericValue() throws Exception {
+        Optional<Integer> result = PagingLinks.getPerPage("https://api.github.com/user/repos?per_page=blah");
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void getPerPage() throws Exception {
+        Optional<Integer> result = PagingLinks.getPerPage("https://api.github.com/user/repos?per_page=50");
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.isPresent());
+        Assert.assertEquals(result.get().intValue(), 50);
+    }
+
+    @Test
+    public void hashCodeEqualWhenDataEqual() throws Exception {
+        PagingLinks result1 = new PagingLinks(Arrays.asList(ALL_HEADERS));
+        PagingLinks result2 = new PagingLinks(Arrays.asList(ALL_HEADERS));
+
+        Assert.assertEquals(result1.hashCode(), result2.hashCode());
+    }
+
+    @Test
+    public void equalsNull() throws Exception {
+        PagingLinks result = new PagingLinks(Arrays.asList(ALL_HEADERS));
+
+        Assert.assertFalse(result.equals(null));
+    }
+
+    @Test
+    public void equalsDifferentClass() throws Exception {
+        PagingLinks result = new PagingLinks(Arrays.asList(ALL_HEADERS));
+
+        Assert.assertFalse(result.equals("string"));
+    }
+
+    @Test
+    public void equalsSelf() throws Exception {
+        PagingLinks result = new PagingLinks(Arrays.asList(ALL_HEADERS));
+
+        Assert.assertTrue(result.equals(result));
+    }
+
+    @Test
+    public void equalsDifferentData() throws Exception {
+        PagingLinks result1 = new PagingLinks(Arrays.asList(ALL_HEADERS));
+        PagingLinks result2 = new PagingLinks(Arrays.asList(MULTIPLE_HEADERS));
+
+        Assert.assertFalse(result1.equals(result2));
+    }
+
+    @Test
+    public void equalsSameData() throws Exception {
+        PagingLinks result1 = new PagingLinks(Arrays.asList(ALL_HEADERS));
+        PagingLinks result2 = new PagingLinks(Arrays.asList(ALL_HEADERS));
+
+        Assert.assertTrue(result1.equals(result2));
+    }
+
+}

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -15,7 +15,7 @@ io.jsonwebtoken:jjwt=0.9.1
 
 org.bouncycastle:bcprov-jdk16=1.46-redhat-2
 
-org.starchartlabs.alloy:alloy-core=0.2.0
+org.starchartlabs.alloy:alloy-core=0.4.0
 
 org.mockito:mockito-core=2.12.0
 


### PR DESCRIPTION
Add paging links and a PageIterator (via Alloy) to allow traversal of any GitHub paged response in a fluent manner