### PR TITLE
 GH-12 Adjust exception thrown due to GitHub error response 

### DIFF
--- a/calamari-core/src/main/java/org/starchartlabs/calamari/core/content/FileContentLoader.java
+++ b/calamari-core/src/main/java/org/starchartlabs/calamari/core/content/FileContentLoader.java
@@ -39,6 +39,9 @@ import okhttp3.ResponseBody;
  * It is intended for an application to create a single loader instance for a configuration file, and utilize
  * {@link #loadContents(InstallationAccessToken, String, String, String)} for each individual repository lookup desired
  *
+ * <p>
+ * If used by a GitHub App, access to the GitHub APIs used requires "contents:read" or "single file:read" permission(s)
+ *
  * @author romeara
  * @since 0.3.0
  */

--- a/calamari-core/src/main/java/org/starchartlabs/calamari/core/content/FileContentLoader.java
+++ b/calamari-core/src/main/java/org/starchartlabs/calamari/core/content/FileContentLoader.java
@@ -20,6 +20,7 @@ import org.starchartlabs.calamari.core.MediaTypes;
 import org.starchartlabs.calamari.core.ResponseConditions;
 import org.starchartlabs.calamari.core.auth.InstallationAccessToken;
 import org.starchartlabs.calamari.core.exception.FileContentException;
+import org.starchartlabs.calamari.core.exception.GitHubResponseException;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -116,7 +117,7 @@ public class FileContentLoader {
             } else if (response.code() != 404) {
                 ResponseConditions.checkRateLimit(response);
 
-                throw new FileContentException(
+                throw new GitHubResponseException(
                         "Request unsuccessful (" + response.code() + " - " + response.message() + ")");
             }
 

--- a/calamari-core/src/test/java/org/starchartlabs/calamari/test/core/content/FileContentLoaderTest.java
+++ b/calamari-core/src/test/java/org/starchartlabs/calamari/test/core/content/FileContentLoaderTest.java
@@ -25,7 +25,7 @@ import org.mockito.MockitoAnnotations;
 import org.starchartlabs.calamari.core.MediaTypes;
 import org.starchartlabs.calamari.core.auth.InstallationAccessToken;
 import org.starchartlabs.calamari.core.content.FileContentLoader;
-import org.starchartlabs.calamari.core.exception.FileContentException;
+import org.starchartlabs.calamari.core.exception.GitHubResponseException;
 import org.starchartlabs.calamari.core.exception.RequestLimitExceededException;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -96,7 +96,7 @@ public class FileContentLoaderTest {
     }
 
 
-    @Test(expectedExceptions = FileContentException.class)
+    @Test(expectedExceptions = GitHubResponseException.class)
     public void loadContentsErrorResponse() throws Exception {
         MockResponse response = new MockResponse()
                 .setResponseCode(412);


### PR DESCRIPTION
Adjust error response to a more appropriate exception for unexpected response codes

Also add doc for the permissions needed to use FileContentReader from a GitHub App

This change does not require additional change log notes - the class modified is already noted as "added" in this release