### PR TITLE
GH-17 Update version and API used of BouncyCastle encryption libraries

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- GH-17 Update to more recent bouncycastle library iterations, and switch to PEMParser from PEMReader
 
 ## [0.3.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 Octo-App(itizers): Utilities for building GitHub Apps
 
-## Importing
+## Using Versions 0.3.0 or Older
 
 Calamari is available on JCenter and Maven Central, but requires the BouncyCastle library for certain operations.
 
-Due to a security patch, this currently requires that consuming projects also allow `https://maven.repository.redhat.com/ga/` as a maven repository source in build configuration
+In versions 0.3.0 and older, Calamari used a security patch of these libraries, which required that consuming projects also allow `https://maven.repository.redhat.com/ga/` as a maven repository source in build configuration
 
 ## Contributing
 

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,6 @@ allprojects{
 
     repositories {
         mavenCentral()
-        maven { url 'https://maven.repository.redhat.com/ga/' }
     }
 
 }

--- a/calamari-core/build.gradle
+++ b/calamari-core/build.gradle
@@ -6,7 +6,8 @@ dependencies {
     compile 'com.squareup.okhttp3:okhttp'
     compile 'commons-codec:commons-codec'
     compile 'io.jsonwebtoken:jjwt'
-    compile 'org.bouncycastle:bcprov-jdk16'
+    compile 'org.bouncycastle:bcpkix-jdk15on'
+    compile 'org.bouncycastle:bcprov-jdk15on'
     compile 'org.slf4j:slf4j-api'
     compile 'org.starchartlabs.alloy:alloy-core'
     

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -13,7 +13,8 @@ commons-codec:commons-codec=1.10
 
 io.jsonwebtoken:jjwt=0.9.1
 
-org.bouncycastle:bcprov-jdk16=1.46-redhat-2
+org.bouncycastle:bcpkix-jdk15on=1.61
+org.bouncycastle:bcprov-jdk15on=1.61
 
 org.starchartlabs.alloy:alloy-core=0.4.0
 


### PR DESCRIPTION
Update to a bouncycastle bc*150n from bc*16, as these are the more
recent and ongoing release artifacts for bouncycastle.

This update involved adjusting the private key reading algorithm in
ApplicationKey, switching off the legacy PEMReader in favor of the
PEMParser

During the update, on the last version PEMReader and PEMParse
co-existed, ApplicationKey production code was updated, and then tested
against the original test (which was still using the PEMReader) to
verify no change in output/behavior, after which the test was also
updated

This change also updates the README to reflect that a separate
repository from Maven Central will no longer be required after the next
release