### PR TITLE
Update JJWT to 0.10.5, and switch to new api/impl artifacts

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - GH-17 Update to more recent bouncycastle library iterations, and switch to PEMParser from PEMReader
+- Update JJWT version, and switch to separated compile/runtime dependency setup
 
 ## [0.3.0]
 ### Added

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - GH-17 Update to more recent bouncycastle library iterations, and switch to PEMParser from PEMReader
 - Update JJWT version, and switch to separated compile/runtime dependency setup
+- Remove dependency on JJWT jackson, replace with local GSON serialization
 
 ## [0.3.0]
 ### Added

--- a/calamari-core/build.gradle
+++ b/calamari-core/build.gradle
@@ -5,11 +5,14 @@ dependencies {
     compile 'com.google.code.gson:gson'
     compile 'com.squareup.okhttp3:okhttp'
     compile 'commons-codec:commons-codec'
-    compile 'io.jsonwebtoken:jjwt'
+    compile 'io.jsonwebtoken:jjwt-api'
     compile 'org.bouncycastle:bcpkix-jdk15on'
     compile 'org.bouncycastle:bcprov-jdk15on'
     compile 'org.slf4j:slf4j-api'
     compile 'org.starchartlabs.alloy:alloy-core'
+    
+    runtime 'io.jsonwebtoken:jjwt-impl'
+    runtime 'io.jsonwebtoken:jjwt-jackson'
     
     testCompile 'com.squareup.okhttp3:mockwebserver'
     testCompile 'org.mockito:mockito-core'

--- a/calamari-core/build.gradle
+++ b/calamari-core/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     compile 'org.starchartlabs.alloy:alloy-core'
     
     runtime 'io.jsonwebtoken:jjwt-impl'
-    runtime 'io.jsonwebtoken:jjwt-jackson'
     
     testCompile 'com.squareup.okhttp3:mockwebserver'
     testCompile 'org.mockito:mockito-core'

--- a/calamari-core/src/main/java/org/starchartlabs/calamari/core/auth/ApplicationKey.java
+++ b/calamari-core/src/main/java/org/starchartlabs/calamari/core/auth/ApplicationKey.java
@@ -122,7 +122,7 @@ public class ApplicationKey implements Supplier<String> {
                     .setIssuedAt(toDate(now))
                     .setExpiration(toDate(expiration))
                     .setIssuer(githubAppId)
-                    .signWith(SignatureAlgorithm.RS256, key);
+                    .signWith(key, SignatureAlgorithm.RS256);
 
             return builder.compact();
         } catch (IOException e) {

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -13,7 +13,6 @@ commons-codec:commons-codec=1.10
 
 io.jsonwebtoken:jjwt-api=0.10.5
 io.jsonwebtoken:jjwt-impl=0.10.5
-io.jsonwebtoken:jjwt-jackson=0.10.5
 
 org.bouncycastle:bcpkix-jdk15on=1.61
 org.bouncycastle:bcprov-jdk15on=1.61

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -11,7 +11,9 @@ com.squareup.okhttp3:okhttp=3.11.0
 
 commons-codec:commons-codec=1.10
 
-io.jsonwebtoken:jjwt=0.9.1
+io.jsonwebtoken:jjwt-api=0.10.5
+io.jsonwebtoken:jjwt-impl=0.10.5
+io.jsonwebtoken:jjwt-jackson=0.10.5
 
 org.bouncycastle:bcpkix-jdk15on=1.61
 org.bouncycastle:bcprov-jdk15on=1.61


### PR DESCRIPTION
After JJWT 0.9.1, the library was split into separate api and
implementation artifacts, meant for use as compile and runtime
dependencies respectively

This change updates to the latest version, and switches to the separated
artifacts. This will allow easier consumption of updates, including
eventually removing use of Jackson JSON handling in favor of GSON, which
is already on the classpath and the preferred JSON implementation