### PR TITLE
Resolves GH-23: Switch to constant-time check in WebhookVerifier

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,10 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- GH-23 Switched to using constant-time `MessageDigest.isEqual(byte[], byte[])` to reduce effectiveness of timing attacks in code using WebhookVerifier
 
 ## [0.3.2]
 ### Changed
-
 - Updated external dependency versions to latest bugfix releases
 
 ## [0.3.1]

--- a/calamari-core/src/main/java/org/starchartlabs/calamari/core/webhook/WebhookVerifier.java
+++ b/calamari-core/src/main/java/org/starchartlabs/calamari/core/webhook/WebhookVerifier.java
@@ -6,6 +6,7 @@
  */
 package org.starchartlabs.calamari.core.webhook;
 
+import java.security.MessageDigest;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -54,7 +55,9 @@ public class WebhookVerifier {
         if (securityKey != null) {
             String expected = "sha1=" + hmacLookup.get().hmacHex(payload);
 
-            result = Objects.equals(securityKey, expected);
+            // MessageDigest.isEqual is used here to guard against timing attacks - it was fixed in Java SE 6u17 to be
+            // resistant to them by using a constant-time algorithm
+            result = MessageDigest.isEqual(securityKey.getBytes(), expected.getBytes());
         }
 
         return result;


### PR DESCRIPTION
Previously, WebhookVerifier delegated to String.equals(Object) to
compare an expected security key and a provided one. This left code
utilizing that implementation more vulnerable to timing attacks, as the
time required to make the comparison varied based on how close to
correct the provided key was.

This change switches the implementation to use
MessageDigest.isEqual(byte[], byte[]), which since Java SE 6u17 has used
a constant-time implementation to reduce the risk of such attacks