### PR TITLE
Resolves GH-34 Configure GitHub authentication to reduce timing errors

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Add missing handling for HTTP response body in InstallationAccessToken
+- (GH-34) Reduce default cache/expiration times for access/installation tokens to reduce possible clock errors with GitHub handshake
+- (GH-34) Add ability to configure cache expiration time for access and installation tokens
 
 ## [0.3.3]
 ### Changed

--- a/calamari-core/src/test/java/org/starchartlabs/calamari/test/core/auth/ApplicationKeyTest.java
+++ b/calamari-core/src/test/java/org/starchartlabs/calamari/test/core/auth/ApplicationKeyTest.java
@@ -53,14 +53,35 @@ public class ApplicationKeyTest {
     }
 
     @Test(expectedExceptions = NullPointerException.class)
-    public void constructNullGitHubAppId() throws Exception {
+    public void constructDefaultCacheNullGitHubAppId() throws Exception {
         new ApplicationKey(null, () -> "string");
     }
 
     @Test(expectedExceptions = NullPointerException.class)
-    public void constructNullPrivateKeySupplier() throws Exception {
+    public void constructDefaultCacheNullPrivateKeySupplier() throws Exception {
         new ApplicationKey("gitHubAppId", null);
     }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullGitHubAppId() throws Exception {
+        new ApplicationKey(null, () -> "string", 5);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullPrivateKeySupplier() throws Exception {
+        new ApplicationKey("gitHubAppId", null, 5);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void constructZeroCacheExpirationMinutes() throws Exception {
+        new ApplicationKey("gitHubAppId", () -> "string", 0);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void constructTooManyCacheExpirationMinutes() throws Exception {
+        new ApplicationKey("gitHubAppId", () -> "string", 11);
+    }
+
 
     @Test(expectedExceptions = KeyLoadingException.class)
     public void getInvalidPrivateKey() throws Exception {

--- a/calamari-core/src/test/java/org/starchartlabs/calamari/test/core/auth/InstallationAccessTokenTest.java
+++ b/calamari-core/src/test/java/org/starchartlabs/calamari/test/core/auth/InstallationAccessTokenTest.java
@@ -59,23 +59,68 @@ public class InstallationAccessTokenTest {
     }
 
     @Test(expectedExceptions = NullPointerException.class)
-    public void constructNullInstallationAccessTokenUrl() throws Exception {
+    public void constructDefaultMediaAndCacheNullInstallationAccessTokenUrl() throws Exception {
         new InstallationAccessToken(null, applicationKey, "userAgent");
     }
 
     @Test(expectedExceptions = NullPointerException.class)
-    public void constructNullApplicationKey() throws Exception {
+    public void constructDefaultMediaAndCacheNullApplicationKey() throws Exception {
         new InstallationAccessToken("http://url", null, "userAgent");
     }
 
     @Test(expectedExceptions = NullPointerException.class)
-    public void constructNullUserAgent() throws Exception {
+    public void constructDefaultMediaAndCacheNullUserAgent() throws Exception {
         new InstallationAccessToken("http://url", applicationKey, null);
     }
 
     @Test(expectedExceptions = NullPointerException.class)
-    public void contructNullMediaType() throws Exception {
+    public void constructDefaultCacheNullInstallationAccessTokenUrl() throws Exception {
+        new InstallationAccessToken(null, applicationKey, "userAgent", "mediaType");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructDefaultCacheNullApplicationKey() throws Exception {
+        new InstallationAccessToken("http://url", null, "userAgent", "mediaType");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructDefaultCacheNullUserAgent() throws Exception {
+        new InstallationAccessToken("http://url", applicationKey, null, "mediaType");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void contructDefaultCacheNullMediaType() throws Exception {
         new InstallationAccessToken("http://url", applicationKey, "userAgent", null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullInstallationAccessTokenUrl() throws Exception {
+        new InstallationAccessToken(null, applicationKey, "userAgent", "mediaType", 5);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullApplicationKey() throws Exception {
+        new InstallationAccessToken("http://url", null, "userAgent", "mediaType", 5);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullUserAgent() throws Exception {
+        new InstallationAccessToken("http://url", applicationKey, null, "mediaType", 5);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void contructNullMediaType() throws Exception {
+        new InstallationAccessToken("http://url", applicationKey, "userAgent", null, 5);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void constructZeroCacheExpiration() throws Exception {
+        new InstallationAccessToken("http://url", applicationKey, "userAgent", "mediaType", 0);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void constructTooManyCacheExpiration() throws Exception {
+        new InstallationAccessToken("http://url", applicationKey, "userAgent", "mediaType", 61);
     }
 
     @Test(expectedExceptions = NullPointerException.class)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # General library settings
 group =org.starchartlabs.calamari
-version=0.3.4-SNAPSHOT
+version=0.4.0-SNAPSHOT
 
 org.gradle.console=plain
 org.gradle.warning.mode=all


### PR DESCRIPTION
Previously, client would sometimes observe 401 responses when attempting
to utilize the access token JWT in requests to GitHub. This can be
caused if GitHub believes an expiration time of greater than 10 minutes
was requested.

To reduce the possibility of this error, this changeset makes two
adjustments. The first is to reduce the default caching and expiration
times of both the access and installation tokesn by one minute, to
decrease the possible timing issues when communicating wiht GitHub. The
second is to make these expiration times configurable, so that clients
with less reliable clocks can further reduce these times themselves if
necessary