### PR TITLE
Update To latest micro (bugfix) versions of external dependencies

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Updated io.jsonwebtoken:jjwt-api and io.jsonwebtoken:jjwt-impl to 0.10.7 from 0.10.6
+- Updated org.bouncycastle:bcpkix-jdk15on and org.bouncycastle:bcprove-jdk15on to 1.64 from 1.63
+- Updated org.slf4j:slf4j-api and org.slf4j:slf4j-simple to 1.7.29 from 1.7.28
 
 ## [0.4.0]
 ### Changed

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -11,17 +11,17 @@ com.squareup.okhttp3:okhttp:3.14.4
 
 commons-codec:commons-codec:1.13
 
-io.jsonwebtoken:jjwt-api:0.10.6
-io.jsonwebtoken:jjwt-impl:0.10.6,implementation
+io.jsonwebtoken:jjwt-api:0.10.7
+io.jsonwebtoken:jjwt-impl:0.10.7,implementation
 
-org.bouncycastle:bcpkix-jdk15on:1.63
-org.bouncycastle:bcprov-jdk15on:1.63
+org.bouncycastle:bcpkix-jdk15on:1.64
+org.bouncycastle:bcprov-jdk15on:1.64
 
 org.starchartlabs.alloy:alloy-core:0.5.0
 
 org.mockito:mockito-core:2.28.2,testImplementation
 
-org.slf4j:slf4j-api:1.7.28
-org.slf4j:slf4j-simple:1.7.28,testImplementation
+org.slf4j:slf4j-api:1.7.29
+org.slf4j:slf4j-simple:1.7.29,testImplementation
 
 org.testng:testng:6.14.3,testImplementation


### PR DESCRIPTION
Update the jjwt, cryptography, and logging libraries used by calamarie
to the latest version for bugfixes and vulnerability updates