### PR TITLE
 Resolves GH-37: Update to OkHttp 4.7.2 from 3.14.4 

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- (GH-37) Update OkHttp to newest major version, 4.7.2
 
 ## [0.4.1]
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 
 Octo-App(itizers): Utilities for building GitHub Apps
 
-## Using Versions 0.3.0 or Older
+## Compatibility
+
+### Major Version Migrations
+
+For steps to migrate between major versions of Calamari, see [the migration guide](./docs/MIGRATION.md)
+
+### Using Versions 0.3.0 or Older
 
 Calamari is available on JCenter and Maven Central, but requires the BouncyCastle library for certain operations.
 

--- a/calamari-core/src/main/java/org/starchartlabs/calamari/core/auth/InstallationAccessToken.java
+++ b/calamari-core/src/main/java/org/starchartlabs/calamari/core/auth/InstallationAccessToken.java
@@ -153,7 +153,7 @@ public class InstallationAccessToken implements Supplier<String> {
     private String generateNewToken() {
         HttpUrl url = HttpUrl.parse(installationAccessTokenUrl);
 
-        RequestBody requestBody = RequestBody.create(null, new byte[] {});
+        RequestBody requestBody = RequestBody.create(new byte[] {}, null);
         Request request = new Request.Builder()
                 .post(requestBody)
                 .header("Authorization", applicationKey.get())

--- a/calamari-core/src/test/java/org/starchartlabs/calamari/test/core/paging/PagingLinksTest.java
+++ b/calamari-core/src/test/java/org/starchartlabs/calamari/test/core/paging/PagingLinksTest.java
@@ -172,7 +172,9 @@ public class PagingLinksTest {
         Assert.assertFalse(result.equals(null));
     }
 
+    // Suppress unlikely argument type, as this test is specifically to validate behavior in that case
     @Test
+    @SuppressWarnings("unlikely-arg-type")
     public void equalsDifferentClass() throws Exception {
         PagingLinks result = new PagingLinks(Arrays.asList(ALL_HEADERS));
 

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -6,8 +6,8 @@ com.google.code.findbugs:jsr305:3.0.2,compileOnly
 
 com.google.code.gson:gson:2.8.6,api
 
-com.squareup.okhttp3:mockwebserver:3.14.4,testImplementation
-com.squareup.okhttp3:okhttp:3.14.4,api
+com.squareup.okhttp3:mockwebserver:4.7.2,testImplementation
+com.squareup.okhttp3:okhttp:4.7.2,api
 
 commons-codec:commons-codec:1.13,api
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,7 @@
+# Major Version Migrations
+
+This details steps for migrating between major versions of Calamari, which may contain breaking changes
+
+## 0.x to 1.x
+
+- Ensure there are no compatibility problems due to differences in OkHttp versions 3.x and 4.x, as transitive dependency has been upgraded

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # General library settings
 group =org.starchartlabs.calamari
-version=0.4.2-SNAPSHOT
+version=1.0.0-SNAPSHOT
 
 org.gradle.console=plain
 org.gradle.warning.mode=all


### PR DESCRIPTION
Update across major versions of OkHttp (during which they switch implementation languages), and add appropriate documentation