### PR TITLE
Resolves GH-20 Replace custom GSON JWT handler with updated JJWT library

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - (GH-37) Update OkHttp to newest major version, 4.7.2
+- (GH-20) Update JJWT to 0.11.2 to allow removal of custom GSON serialization handling
 
 ## [0.4.1]
 ### Changed

--- a/calamari-core/build.gradle
+++ b/calamari-core/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     api 'org.slf4j:slf4j-api'
     api 'org.starchartlabs.alloy:alloy-core'
     
+    implementation 'io.jsonwebtoken:jjwt-gson'
     implementation 'io.jsonwebtoken:jjwt-impl'
     
     testImplementation 'com.squareup.okhttp3:mockwebserver'

--- a/calamari-core/src/main/java/org/starchartlabs/calamari/core/auth/ApplicationKey.java
+++ b/calamari-core/src/main/java/org/starchartlabs/calamari/core/auth/ApplicationKey.java
@@ -8,7 +8,6 @@ package org.starchartlabs.calamari.core.auth;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.KeyPair;
 import java.security.Security;
@@ -31,14 +30,11 @@ import org.starchartlabs.alloy.core.Strings;
 import org.starchartlabs.alloy.core.Suppliers;
 import org.starchartlabs.calamari.core.exception.KeyLoadingException;
 
-import com.google.gson.Gson;
-
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.io.SerializationException;
+import io.jsonwebtoken.gson.io.GsonSerializer;
 import io.jsonwebtoken.io.Serializer;
-import io.jsonwebtoken.lang.Assert;
 
 /**
  * Represents an authentication key used to validate web requests to GitHub as a
@@ -186,41 +182,6 @@ public class ApplicationKey implements Supplier<String> {
         Instant instant = input.toInstant();
 
         return new Date(instant.toEpochMilli());
-    }
-
-    /**
-     * Implementation-specific serializer which uses GSON with JJWT for JSON handling
-     *
-     * <p>
-     * Necessary until <a href="https://github.com/jwtk/jjwt/pull/414">JJWT's pull request</a> to add a standard GSON
-     * implementation is merged and released
-     *
-     * @author romeara
-     *
-     * @param <T>
-     *            Type to serialize
-     */
-    private static final class GsonSerializer<T> implements Serializer<T> {
-
-        private final Gson gson;
-
-        public GsonSerializer() {
-            this.gson = new Gson();
-        }
-
-        @Override
-        public byte[] serialize(T t) throws SerializationException {
-            Assert.notNull(t, "Object to serialize cannot be null.");
-            try {
-                return writeValueAsBytes(t);
-            } catch (Exception e) {
-                throw new SerializationException("Unable to serialize object: " + e.getMessage(), e);
-            }
-        }
-
-        private byte[] writeValueAsBytes(T t) {
-            return gson.toJson(t).getBytes(StandardCharsets.UTF_8);
-        }
     }
 
 }

--- a/calamari-core/src/test/java/org/starchartlabs/calamari/test/core/auth/ApplicationKeyTest.java
+++ b/calamari-core/src/test/java/org/starchartlabs/calamari/test/core/auth/ApplicationKeyTest.java
@@ -29,13 +29,10 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.google.gson.Gson;
-
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.io.DeserializationException;
-import io.jsonwebtoken.io.Deserializer;
+import io.jsonwebtoken.gson.io.GsonDeserializer;
 
 public class ApplicationKeyTest {
 
@@ -116,9 +113,10 @@ public class ApplicationKeyTest {
             KeyPair keyPair = converter.getKeyPair(pemKeyPair);
             Key publicKey = keyPair.getPublic();
 
-            Jws<Claims> generatedKey = Jwts.parser()
+            Jws<Claims> generatedKey = Jwts.parserBuilder()
                     .deserializeJsonWith(new GsonDeserializer<>())
                     .setSigningKey(publicKey)
+                    .build()
                     .parseClaimsJws(jwt);
 
             Claims claims = generatedKey.getBody();
@@ -199,34 +197,6 @@ public class ApplicationKeyTest {
             return count;
         }
 
-    }
-
-    private static class GsonDeserializer<T> implements Deserializer<T> {
-
-        private final Class<T> returnType;
-
-        private final Gson gson;
-
-        @SuppressWarnings("unchecked")
-        public GsonDeserializer() {
-            this.gson = new Gson();
-            this.returnType = (Class<T>) Object.class;
-        }
-
-        @Override
-        public T deserialize(byte[] bytes) throws DeserializationException {
-            try {
-                return readValue(bytes);
-            } catch (Exception e) {
-                String msg = "Unable to deserialize bytes into a " + returnType.getName() + " instance: "
-                        + e.getMessage();
-                throw new DeserializationException(msg, e);
-            }
-        }
-
-        protected T readValue(byte[] bytes) throws IOException {
-            return gson.fromJson(new String(bytes, StandardCharsets.UTF_8), returnType);
-        }
     }
 
 }

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -11,8 +11,10 @@ com.squareup.okhttp3:okhttp:4.7.2,api
 
 commons-codec:commons-codec:1.13,api
 
-io.jsonwebtoken:jjwt-api:0.10.7,api
-io.jsonwebtoken:jjwt-impl:0.10.7,implementation
+io.jsonwebtoken:jjwt-api:0.11.2,api
+io.jsonwebtoken:jjwt-gson:0.11.2,implementation
+io.jsonwebtoken:jjwt-impl:0.11.2,implementation
+
 
 org.bouncycastle:bcpkix-jdk15on:1.64,api
 org.bouncycastle:bcprov-jdk15on:1.64,api


### PR DESCRIPTION
Update JJWT 0.11.2, which includes a GSON serialization handler. This
allows removal of a custom GSON serializer implementation within the
Calamari library