### PR TITLE
Resolves GH-54 Add generation of request limit exception without throw

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- (GH-54) Added a response utility to generate a request limit exceeded exception, without immeadiately throwing it
 
 ## [1.0.2]
 ### Changed


### PR DESCRIPTION
Allow generation of the request limit exceeded exception without
immeadiately throwing it, for streaming response situations such as
`Mono.onErrorMap`